### PR TITLE
Fix green whitespace

### DIFF
--- a/src/com/powertuple/intellij/haskell/HaskellParserDefinition.scala
+++ b/src/com/powertuple/intellij/haskell/HaskellParserDefinition.scala
@@ -27,7 +27,7 @@ import com.powertuple.intellij.haskell.psi.HaskellTypes._
 import org.jetbrains.annotations.NotNull
 
 object HaskellParserDefinition {
-  final val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE, HS_NEWLINE)
+  final val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
   final val COMMENTS = TokenSet.create(HS_COMMENT, HS_NCOMMENT)
   final val PRAGMA_START_END_IDS = TokenSet.create(HS_PRAGMA_START, HS_PRAGMA_END)
   final val RESERVED_IDS = TokenSet.create(HS_CASE, HS_CLASS, HS_DATA, HS_DEFAULT, HS_DERIVING, HS_DO, HS_ELSE, HS_IF, HS_IMPORT,

--- a/src/com/powertuple/intellij/haskell/HaskellParserDefinition.scala
+++ b/src/com/powertuple/intellij/haskell/HaskellParserDefinition.scala
@@ -27,7 +27,7 @@ import com.powertuple.intellij.haskell.psi.HaskellTypes._
 import org.jetbrains.annotations.NotNull
 
 object HaskellParserDefinition {
-  final val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
+  final val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE, HS_NEWLINE)
   final val COMMENTS = TokenSet.create(HS_COMMENT, HS_NCOMMENT)
   final val PRAGMA_START_END_IDS = TokenSet.create(HS_PRAGMA_START, HS_PRAGMA_END)
   final val RESERVED_IDS = TokenSet.create(HS_CASE, HS_CLASS, HS_DATA, HS_DEFAULT, HS_DERIVING, HS_DO, HS_ELSE, HS_IF, HS_IMPORT,

--- a/src/com/powertuple/intellij/haskell/highlighter/HaskellSyntaxHighlighter.scala
+++ b/src/com/powertuple/intellij/haskell/highlighter/HaskellSyntaxHighlighter.scala
@@ -42,7 +42,7 @@ object HaskellSyntaxHighlighter {
   final val Operator = createTextAttributesKey("HS_OPERATOR", CodeInsightColors.TYPE_PARAMETER_NAME_ATTRIBUTES)
   final val ReservedSymbol = createTextAttributesKey("HS_SYMBOL", DefaultLanguageHighlighterColors.INSTANCE_METHOD)
   final val Pragma = createTextAttributesKey("HS_PRAGMA", DefaultLanguageHighlighterColors.PREDEFINED_SYMBOL)
-  final val Default = createTextAttributesKey("HS_DEFAULT", DefaultLanguageHighlighterColors.DOC_COMMENT_MARKUP)
+  final val Default = createTextAttributesKey("HS_DEFAULT", DefaultLanguageHighlighterColors.COMMA)
 }
 
 class HaskellSyntaxHighlighter extends SyntaxHighlighterBase {

--- a/src/com/powertuple/intellij/haskell/highlighter/HaskellSyntaxHighlighter.scala
+++ b/src/com/powertuple/intellij/haskell/highlighter/HaskellSyntaxHighlighter.scala
@@ -74,7 +74,7 @@ class HaskellSyntaxHighlighter extends SyntaxHighlighterBase {
       case et if OPERATORS.contains(et) => pack(Operator)
       case et if et == HS_VARID_ID => pack(Variable)
       case et if et == HS_CONID_ID => pack(Constructor)
-      case et if WHITE_SPACES.contains(et) => pack(null)
+      case et if WHITE_SPACES.contains(et) || et == HS_NEWLINE => pack(null)
       case _ => pack(Default)
     }
   }

--- a/src/com/powertuple/intellij/haskell/highlighter/HaskellSyntaxHighlighter.scala
+++ b/src/com/powertuple/intellij/haskell/highlighter/HaskellSyntaxHighlighter.scala
@@ -74,6 +74,7 @@ class HaskellSyntaxHighlighter extends SyntaxHighlighterBase {
       case et if OPERATORS.contains(et) => pack(Operator)
       case et if et == HS_VARID_ID => pack(Variable)
       case et if et == HS_CONID_ID => pack(Constructor)
+      case et if WHITE_SPACES.contains(et) => pack(null)
       case _ => pack(Default)
     }
   }


### PR DESCRIPTION
Remove styles for whitespace, and makes Default inherit from the non-green Comma style. See issue #24.