### PR TITLE
Allow multiple developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /src/com/powertuple/intellij/haskell/_HaskellLexer.java
 idea-flex.skeleton
 JFlex.jar
+/intellij-haskell.zip

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA IU-141.1010.3" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA IU-141" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/intellij-haskell.iml
+++ b/intellij-haskell.iml
@@ -10,7 +10,7 @@
       <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
     </content>
-    <orderEntry type="jdk" jdkName="IntelliJ IDEA IU-141.1010.3" jdkType="IDEA JDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="TEST" name="scalatest" level="project" />
     <orderEntry type="library" name="spray-json_2.11-1.3.1" level="project" />


### PR DESCRIPTION
Modifications to the project files, so they can be shared between plugin developers that have different minor IntelliJ SDK versions (without having dirty files in git that can be accidentally included in pull requests). It's not extremely elegant, but I've checked with JetBrains, and they confirmed there was no better way to do this.