### PR TITLE
turn on hlint inspection by default

### DIFF
--- a/intellij-haskell/META-INF/plugin.xml
+++ b/intellij-haskell/META-INF/plugin.xml
@@ -169,7 +169,7 @@
         <typedHandler implementation="intellij.haskell.code.HaskellTypedHandler" id="HaskellFile"/>
 
         <localInspection language="Haskell" shortName="HLintInspection" displayName="Inspection by HLint"
-                         groupName="Haskell" enabledByDefault="false" level="WARNING"
+                         groupName="Haskell" enabledByDefault="true" level="WARNING"
                          implementationClass="intellij.haskell.inspection.HlintInspectionTool"/>
 
         <lang.importOptimizer language="Haskell" implementationClass="intellij.haskell.code.HaskellImportOptimizer"/>

--- a/src/main/scala/intellij/haskell/external/Hlint.scala
+++ b/src/main/scala/intellij/haskell/external/Hlint.scala
@@ -31,7 +31,26 @@ object Hlint {
           p,
           Seq("--json", psiFile.getVirtualFile.getPath)
         )
-        deserializeHlintInfo(output.getStdout)
+        val infos = deserializeHlintInfo(output.getStdout)
+        infos.map((info: HlintInfo) => {
+          val found = info.from
+          val suggest = info.to.getOrElse("")
+          val hint = List(info.hint, "Found:", found, "Why not:", suggest).mkString("\n")
+          HlintInfo(
+            info.module,
+            info.decl,
+            info.severity,
+            hint,
+            info.file,
+            info.startLine,
+            info.startColumn,
+            info.endLine,
+            info.endColumn,
+            info.from,
+            info.to,
+            info.note
+          )
+        })
       case None => Seq()
     }
   }


### PR DESCRIPTION
Fix #37 

@rikvdkleij 

and btw, maybe we should refactor https://github.com/rikvdkleij/intellij-haskell/blob/master/src/main/scala/intellij/haskell/inspection/HlintQuickfix.scala to get a better quick fix functionality.

for now it just doesn't work out sometimes.

![report](https://cloud.githubusercontent.com/assets/6234553/14765884/f309279e-0a28-11e6-97ac-49c8f948ea8d.gif)
