### PR TITLE
Fix parsing issues on windows

### DIFF
--- a/src/main/scala/intellij/haskell/external/component/NameInfoComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/NameInfoComponent.scala
@@ -35,8 +35,8 @@ import scala.collection.JavaConversions._
 private[component] object NameInfoComponent {
 
   private final val ProjectInfoPattern = """(.+)-- Defined at (.+):([\d]+):([\d]+)""".r
-  private final val LibraryModuleInfoPattern = """(.+)-- Defined in ‘([\w\.\-]+):([\w\.\-]+)’""".r
-  private final val ModuleInfoPattern = """(.+)-- Defined in ‘([\w\.\-]+)’""".r
+  private final val LibraryModuleInfoPattern = """(.+)-- Defined in [`|‘]([\w\.\-]+):([\w\.\-]+)['|’]""".r
+  private final val ModuleInfoPattern = """(.+)-- Defined in [`|‘]([\w\.\-]+)['|’]""".r
 
   private final val Executor = Executors.newCachedThreadPool()
 


### PR DESCRIPTION
The issue was with different formating of the output of `:info` on windows.
On linux:
`dropWhile :: (a -> Bool) -> [a] -> [a] 	-- Defined in ‘GHC.List’`
On windows:
```dropWhile :: (a -> Bool) -> [a] -> [a] 	-- Defined in `GHC.List'```
(note the ticks)
