### PR TITLE
Sync module name when rename file

### DIFF
--- a/intellij-haskell/META-INF/plugin.xml
+++ b/intellij-haskell/META-INF/plugin.xml
@@ -181,6 +181,7 @@
                              implementationClass="intellij.haskell.refactor.HaskellNamesValidator"/>
         <lang.refactoringSupport language="Haskell"
                                  implementationClass="intellij.haskell.refactor.HaskellRefactoringSupportProvider"/>
+        <renamePsiElementProcessor implementation="intellij.haskell.refactor.HaskellRenameFileProcessor"/>
         <renamePsiElementProcessor implementation="intellij.haskell.refactor.HaskellRenameVariableProcessor"/>
         <vetoRenameCondition implementation="intellij.haskell.refactor.HaskellVetoRenameCondition"/>
 

--- a/src/main/scala/intellij/haskell/psi/HaskellReferenceContributor.scala
+++ b/src/main/scala/intellij/haskell/psi/HaskellReferenceContributor.scala
@@ -30,6 +30,7 @@ class HaskellReferenceContributor extends PsiReferenceContributor {
       @NotNull
       def getReferencesByElement(@NotNull element: PsiElement, @NotNull context: ProcessingContext): Array[PsiReference] = {
         element match {
+          case _: HaskellModid => PsiReference.EMPTY_ARRAY
           case ne: HaskellNamedElement => Array(new HaskellReference(ne, TextRange.from(0, element.getTextLength)))
           case _ => PsiReference.EMPTY_ARRAY
         }

--- a/src/main/scala/intellij/haskell/refactor/HaskellRenameFileProcessor.scala
+++ b/src/main/scala/intellij/haskell/refactor/HaskellRenameFileProcessor.scala
@@ -1,0 +1,34 @@
+package intellij.haskell.refactor
+
+import java.util
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.rename.RenamePsiElementProcessor
+import intellij.haskell.HaskellFile
+import intellij.haskell.psi.HaskellModid
+import intellij.haskell.util.HaskellProjectUtil
+import org.apache.commons.lang.StringUtils
+
+class HaskellRenameFileProcessor extends RenamePsiElementProcessor {
+  override def canProcessElement(element: PsiElement): Boolean =
+    HaskellProjectUtil.isHaskellStackProject(element.getProject) && element.isInstanceOf[HaskellFile]
+
+  override def prepareRenaming(element: PsiElement, newName: String, allRenames: util.Map[PsiElement, String]): Unit = {
+    val haskellModuledecl = PsiTreeUtil.findChildOfType(element, classOf[HaskellModid])
+    if (haskellModuledecl != null) {
+      val conids = haskellModuledecl.getText.split("\\.")
+      conids(conids.length - 1) = createCorrectModuleName(newName)
+      allRenames.put(haskellModuledecl, conids.mkString("."))
+    }
+    super.prepareRenaming(element, newName, allRenames)
+  }
+
+  def createCorrectModuleName(newName: String): String = {
+    if (StringUtils.endsWith(newName, ".hs")) {
+      StringUtils.removeEnd(newName, ".hs")
+    } else {
+      newName
+    }
+  }
+}

--- a/src/main/scala/intellij/haskell/refactor/HaskellRenameVariableProcessor.scala
+++ b/src/main/scala/intellij/haskell/refactor/HaskellRenameVariableProcessor.scala
@@ -22,13 +22,16 @@ import com.intellij.psi.{PsiElement, PsiReference}
 import com.intellij.refactoring.listeners.RefactoringElementListener
 import com.intellij.refactoring.rename.RenamePsiElementProcessor
 import com.intellij.usageView.UsageInfo
+import intellij.haskell.psi.HaskellNamedElement
 import intellij.haskell.util.{HaskellFileIndex, HaskellFileUtil, HaskellProjectUtil}
 
 import scala.collection.JavaConverters._
 
 class HaskellRenameVariableProcessor extends RenamePsiElementProcessor {
 
-  override def canProcessElement(element: PsiElement): Boolean = HaskellProjectUtil.isHaskellStackProject(element.getProject)
+  override def canProcessElement(element: PsiElement): Boolean = {
+    HaskellProjectUtil.isHaskellStackProject(element.getProject) && element.isInstanceOf[HaskellNamedElement]
+  }
 
   override def renameElement(element: PsiElement, newName: String, usages: Array[UsageInfo], listener: RefactoringElementListener): Unit = {
     super.renameElement(element, newName, usages, listener)


### PR DESCRIPTION
## Implemented

* Renaming a file should rename the module name without the module prefix.

![screenshot](https://cloud.githubusercontent.com/assets/6234553/20997277/02c6bcfe-bd3f-11e6-919f-4f6f02591590.gif)

## Future work

1. Currently, I just ignore the references between `HS_MODID` and Haskell files [here](https://github.com/zjhmale/intellij-haskell/blob/bc9582666cccee8f9e538dd070cc99018fb36512/src/main/scala/intellij/haskell/psi/HaskellReferenceContributor.scala#L33) in order to make sure the renaming file action work as expected, but we can not rename module name anymore.

![screenshot](https://cloud.githubusercontent.com/assets/6234553/20996765/f303739c-bd3a-11e6-9058-316ed7980cdf.gif)

  So maybe the references of `HS_MODID`  [here](https://github.com/rikvdkleij/intellij-haskell/blob/master/src/main/scala/intellij/haskell/navigation/HaskellReference.scala#L41) can be improved? In the old way, renaming a file and renaming module name will override the module prefix.

![screenshot](https://cloud.githubusercontent.com/assets/6234553/20997198/54b085d2-bd3e-11e6-88fe-fe910b99fa42.gif)

2. Rename package name should also rename the module prefix, maybe [DirectoryAsPackageRenameHandlerBase](https://github.com/JetBrains/intellij-community/blob/master/platform/lang-impl/src/com/intellij/refactoring/rename/DirectoryAsPackageRenameHandlerBase.java) can do the job.