### PR TITLE
Fix internalFileTemplate

### DIFF
--- a/intellij-haskell/META-INF/plugin.xml
+++ b/intellij-haskell/META-INF/plugin.xml
@@ -142,7 +142,7 @@
         <moduleConfigurationEditorProvider implementation="intellij.haskell.settings.HaskellModuleEditorsProvider"
                                            order="first"/>
 
-        <internalFileTemplate name="Haskell"/>
+        <internalFileTemplate name="Haskell Module"/>
 
         <fileTypeFactory implementation="intellij.haskell.HaskellLanguageFileTypeFactory"/>
 


### PR DESCRIPTION
Related with #70.

@rikvdkleij Now the template in Settings/CodeTemplates is the same as the that is used when creating a new file.

![image](https://cloud.githubusercontent.com/assets/6234553/21081689/afb38ca2-c006-11e6-97a2-0ce65b6586ed.png)
