### PR TITLE
Improve redundant import intention

### DIFF
--- a/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
+++ b/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
@@ -51,7 +51,7 @@ class HaskellAnnotator extends ExternalAnnotator[PsiFile, LoadResult] {
   private final val NotInScopePattern = """.* Not in scope:[^‘`]+[‘`](.+)[’']""".r
   private final val NotInScopePattern2 = """.* not in scope: (.+)""".r
   private final val UseAloneInstancesImportPattern = """.* To import instances alone, use: (.+)""".r
-  private final val RedundantImportPattern = """.* The import of ‘(.*)’ from module ‘(.*)’ is redundant""".r
+  private final val RedundantImportPattern = """.* The import of [‘`](.*)[’'] from module [‘`](.*)[’'] is redundant""".r
 
   private final val PerhapsYouMeantNamePattern = """.*[`‘]([^‘’'`]+)['’]""".r
   private final val PerhapsYouMeantMultiplePattern = """.*ot in scope: (.+) Perhaps you meant one of these: (.+)""".r
@@ -388,7 +388,7 @@ class RedundantImportAction(moduleName: String, redundants: String) extends Hask
   def removeRedundants(spec: String, redundants: String): String = {
     val specArr = spec.stripPrefix("(").stripSuffix(")").split(",").map(_.trim)
     val redundantsArr = redundants.split(",").map(_.trim)
-    specArr.filter(e => !redundantsArr.contains(e.replace("(..)", ""))).mkString(", ")
+    specArr.filterNot(e => redundantsArr.contains(e.replace("(..)", ""))).mkString(", ")
   }
 
   override def invoke(project: Project, editor: Editor, file: PsiFile): Unit = {


### PR DESCRIPTION
@rikvdkleij Address issues of redundant import intention.

BTW, I still don't understand, why we only need ```[‘`](.+)[’']``` instead of ```[‘'`](.+)[’'`]``` in `DefinedButNotUsedPattern`. Do we miss a quote ```[']``` on the left and a quasi quote ```[`]``` on the right?