### PR TITLE
Use html highlight tag

### DIFF
--- a/src/main/scala/intellij/haskell/action/HindentFormatAction.scala
+++ b/src/main/scala/intellij/haskell/action/HindentFormatAction.scala
@@ -80,7 +80,7 @@ object HindentFormatAction {
         formattedSourceCode.foreach {
           case Left(e) =>
             HaskellNotificationGroup.logErrorEvent(project, e)
-            HaskellNotificationGroup.logErrorBalloonEvent(project, s"Error while formatting by `$HindentName`. See Event Log for errors")
+            HaskellNotificationGroup.logErrorBalloonEvent(project, s"Error while formatting by <b>$HindentName</b>. See Event Log for errors")
           case Right(sourceCode) =>
             selectionModel match {
               case Some(sm) => HaskellFileUtil.saveFileWithPartlyNewContent(psiFile.getProject, virtualFile, sourceCode, sm)
@@ -88,7 +88,7 @@ object HindentFormatAction {
             }
         }
 
-      case _ => HaskellNotificationGroup.logWarningEvent(project, "Can not format code because path to `hindent` is not configured in IntelliJ")
+      case _ => HaskellNotificationGroup.logWarningEvent(project, s"Can not format code because path to `$HindentName` is not configured in IntelliJ")
     }
   }
 

--- a/src/main/scala/intellij/haskell/action/StylishHaskellFormatAction.scala
+++ b/src/main/scala/intellij/haskell/action/StylishHaskellFormatAction.scala
@@ -52,7 +52,7 @@ object StylishHaskellFormatAction {
         processOutput.foreach(output => if (output.getStderrLines.isEmpty) {
           HaskellFileUtil.saveFileWithNewContent(psiFile.getProject, virtualFile, output.getStdout)
         } else {
-          HaskellNotificationGroup.logErrorBalloonEvent(project, s"Error while formatting by `$StylishHaskellName`. See Event Log for errors")
+          HaskellNotificationGroup.logErrorBalloonEvent(project, s"Error while formatting by <b>$StylishHaskellName</b>. See Event Log for errors")
         })
 
       case _ => HaskellNotificationGroup.logWarningEvent(project, s"Can not format code because path to `$StylishHaskellName` is not configured in IntelliJ")

--- a/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
+++ b/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
@@ -104,7 +104,7 @@ class HaskellAnnotator extends ExternalAnnotator[PsiFile, LoadResult] {
     val project = psiFile.getProject
     if (loadResult.loadFailed && loadResult.currentFileProblems.isEmpty) {
       loadResult.otherFileProblems.foreach {
-        case cpf: LoadProblemInOtherFile => HaskellNotificationGroup.logInfoBalloonEvent(project, s"Error in file `${cpf.filePath}`: ${cpf.htmlMessage}")
+        case cpf: LoadProblemInOtherFile => HaskellNotificationGroup.logInfoBalloonEvent(project, s"Error in file <b>${cpf.filePath}</b>: ${cpf.htmlMessage}")
         case cpf: LoadProblemWithoutLocation => HaskellNotificationGroup.logInfoBalloonEvent(project, s"Error ${cpf.htmlMessage}")
         case _ => ()
       }

--- a/src/main/scala/intellij/haskell/external/commandLine/CommandLine.scala
+++ b/src/main/scala/intellij/haskell/external/commandLine/CommandLine.scala
@@ -48,10 +48,10 @@ object CommandLine {
 
     val processOutput = processHandler.runProcess(timeout.toInt, true)
     if (processOutput.isTimeout) {
-      HaskellNotificationGroup.logErrorBalloonEvent(project, s"Timeout while executing `${cmd.getCommandLineString}`")
+      HaskellNotificationGroup.logErrorBalloonEvent(project, s"Timeout while executing <b>${cmd.getCommandLineString}</b>")
       None
     } else if (!captureOutputToLog && !processOutput.getStderrLines.isEmpty) {
-      HaskellNotificationGroup.logErrorEvent(project, s"Error while executing` ${cmd.getCommandLineString}`:  ${processOutput.getStderr}")
+      HaskellNotificationGroup.logErrorEvent(project, s"Error while executing `${cmd.getCommandLineString}`:  ${processOutput.getStderr}")
       Option(processOutput)
     } else {
       Option(processOutput)

--- a/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
@@ -32,7 +32,7 @@ object HLintComponent {
     StackCommandLine.runCommand(Seq("exec", "--", HlintName, "--json", psiFile.getOriginalFile.getVirtualFile.getPath), project).map(output => {
       if (output.getStderr.nonEmpty) {
         if (output.getStderr.toLowerCase.contains("couldn't find file: hlint")) {
-          HaskellNotificationGroup.logWarningBalloonEvent(project, "No Hlint suggestions because `hlint` build still has to be started or build is not finished yet")
+          HaskellNotificationGroup.logWarningBalloonEvent(project, s"No Hlint suggestions because <b>$HlintName</b> build still has to be started or build is not finished yet")
         }
       }
       deserializeHLintInfo(project, output.getStdout)

--- a/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
+++ b/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
@@ -55,7 +55,7 @@ class HaskellDocumentationProvider extends AbstractDocumentationProvider {
     StackCommandLine.runCommand(Seq("exec", "--", HaskellDocsName) ++ args, namedElement.getContainingFile.getProject).map(output => {
       if (output.getStderr.nonEmpty) {
         if (output.getStderr.toLowerCase.contains("couldn't find file: haskell-docs")) {
-          HaskellNotificationGroup.logWarningBalloonEvent(namedElement.getProject, "No documentation because `haskell-docs` build still has to be started or build is not finished yet")
+          HaskellNotificationGroup.logWarningBalloonEvent(namedElement.getProject, s"No documentation because <b>$HaskellDocsName</b> build still has to be started or build is not finished yet")
         }
       }
       output.getStdout

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
@@ -35,7 +35,7 @@ object HaskellSettingsState {
 
   private def notifyIfPathIsNotSet(path: Option[String], name: String) {
     if (path.isEmpty) {
-      HaskellNotificationGroup.logErrorBalloonEvent("Path to `" + name + "` is not set. Please do in `Settings`/`Other Settings`/`Haskell`")
+      HaskellNotificationGroup.logErrorBalloonEvent(s"Path to <b>$name</b> is not set. Please do in <b>Settings</b>/<b>Other Settings</b>/<b>Haskell</b>")
     }
   }
 


### PR DESCRIPTION
IntelliJ uses HTML syntax internally instead of markdown syntax, so maybe it is better to use HTML highlight tag in balloon notifications.

![image](https://cloud.githubusercontent.com/assets/6234553/21503230/d1b7e866-cc90-11e6-87b3-5edce7c33d20.png)

