### PR TITLE
Use exit code to check executables

### DIFF
--- a/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
@@ -30,10 +30,8 @@ object HLintComponent {
   def check(psiFile: PsiFile): Seq[HLintInfo] = {
     val project = psiFile.getProject
     StackCommandLine.runCommand(Seq("exec", "--", HlintName, "--json", psiFile.getOriginalFile.getVirtualFile.getPath), project).map(output => {
-      if (output.getStderr.nonEmpty) {
-        if (output.getStderr.toLowerCase.contains("couldn't find file: hlint")) {
-          HaskellNotificationGroup.logWarningBalloonEvent(project, s"No Hlint suggestions because <b>$HlintName</b> build still has to be started or build is not finished yet.")
-        }
+      if (output.getExitCode == 1) {
+        HaskellNotificationGroup.logWarningBalloonEvent(project, s"No Hlint suggestions because <b>$HlintName</b> build still has to be started or build is not finished yet.")
       }
       deserializeHLintInfo(project, output.getStdout)
     }).getOrElse(Seq())

--- a/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
@@ -31,7 +31,7 @@ object HLintComponent {
     val project = psiFile.getProject
     StackCommandLine.runCommand(Seq("exec", "--", HlintName, "--json", psiFile.getOriginalFile.getVirtualFile.getPath), project).map(output => {
       if (output.getExitCode != 0) {
-        HaskellNotificationGroup.logWarningBalloonEvent(project, s"Something went wrong while calling <b>$HlintName</b>. ${output.getStderr}. See event log for more info.")
+        HaskellNotificationGroup.logErrorBalloonEvent(project, s"Something went wrong while calling <b>$HlintName</b>. ${output.getStderr}. See event log for more info.")
       }
       deserializeHLintInfo(project, output.getStdout)
     }).getOrElse(Seq())

--- a/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
@@ -30,8 +30,8 @@ object HLintComponent {
   def check(psiFile: PsiFile): Seq[HLintInfo] = {
     val project = psiFile.getProject
     StackCommandLine.runCommand(Seq("exec", "--", HlintName, "--json", psiFile.getOriginalFile.getVirtualFile.getPath), project).map(output => {
-      if (output.getExitCode == 1) {
-        HaskellNotificationGroup.logWarningBalloonEvent(project, s"No Hlint suggestions because <b>$HlintName</b> build still has to be started or build is not finished yet.")
+      if (output.getExitCode != 0) {
+        HaskellNotificationGroup.logWarningBalloonEvent(project, s"Something went wrong while calling <b>$HlintName</b>. ${output.getStderr}. See event log for more info.")
       }
       deserializeHLintInfo(project, output.getStdout)
     }).getOrElse(Seq())

--- a/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
+++ b/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
@@ -53,8 +53,8 @@ class HaskellDocumentationProvider extends AbstractDocumentationProvider {
 
   private def runHaskellDocs(namedElement: HaskellQualifiedNameElement, args: Seq[String]): Option[String] = {
     StackCommandLine.runCommand(Seq("exec", "--", HaskellDocsName) ++ args, namedElement.getContainingFile.getProject).map(output => {
-      if (output.getExitCode == 1) {
-        HaskellNotificationGroup.logWarningBalloonEvent(namedElement.getProject, s"No documentation because <b>$HaskellDocsName</b> build still has to be started or build is not finished yet.")
+      if (output.getExitCode != 0) {
+        HaskellNotificationGroup.logWarningBalloonEvent(namedElement.getProject, s"Something went wrong while calling <b>$HaskellDocsName</b>. ${output.getStderr}. See event log for more info.")
       }
       output.getStdout
     })

--- a/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
+++ b/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
@@ -54,7 +54,7 @@ class HaskellDocumentationProvider extends AbstractDocumentationProvider {
   private def runHaskellDocs(namedElement: HaskellQualifiedNameElement, args: Seq[String]): Option[String] = {
     StackCommandLine.runCommand(Seq("exec", "--", HaskellDocsName) ++ args, namedElement.getContainingFile.getProject).map(output => {
       if (output.getExitCode != 0) {
-        HaskellNotificationGroup.logWarningBalloonEvent(namedElement.getProject, s"Something went wrong while calling <b>$HaskellDocsName</b>. ${output.getStderr}. See event log for more info.")
+        HaskellNotificationGroup.logErrorBalloonEvent(namedElement.getProject, s"Something went wrong while calling <b>$HaskellDocsName</b>. ${output.getStderr}. See event log for more info.")
       }
       output.getStdout
     })

--- a/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
+++ b/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
@@ -53,10 +53,8 @@ class HaskellDocumentationProvider extends AbstractDocumentationProvider {
 
   private def runHaskellDocs(namedElement: HaskellQualifiedNameElement, args: Seq[String]): Option[String] = {
     StackCommandLine.runCommand(Seq("exec", "--", HaskellDocsName) ++ args, namedElement.getContainingFile.getProject).map(output => {
-      if (output.getStderr.nonEmpty) {
-        if (output.getStderr.toLowerCase.contains("couldn't find file: haskell-docs")) {
-          HaskellNotificationGroup.logWarningBalloonEvent(namedElement.getProject, s"No documentation because <b>$HaskellDocsName</b> build still has to be started or build is not finished yet.")
-        }
+      if (output.getExitCode == 1) {
+        HaskellNotificationGroup.logWarningBalloonEvent(namedElement.getProject, s"No documentation because <b>$HaskellDocsName</b> build still has to be started or build is not finished yet.")
       }
       output.getStdout
     })


### PR DESCRIPTION
Currently if stack can not find an executable it will produce the stderr

>Executable named xxx not found on path: ...

So maybe it is better to check executables using exit code.

![image](https://cloud.githubusercontent.com/assets/6234553/21503178/51e1498e-cc90-11e6-9112-80ba2daae006.png)

@rikvdkleij BTW, if I remove hlint from the path, and I can not locate the hlint executable using `which hlint` any more, `stack exec -- hlint` still works fine, can you explain the details under the hood?