### PR TITLE
Specify source encoding in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,3 +22,5 @@ lazy val intellijHaskell = (project in file(".")).
   )
 
 ideaBuild in ThisBuild := "163.7743.44"
+
+javacOptions ++= Seq("-encoding", "UTF-8")


### PR DESCRIPTION
This is required to build this project on my machine: Windows 10 in Japanese.