### PR TITLE
Remove duplicate typo hint

### DIFF
--- a/src/main/resources/dictionary/haskell.dic
+++ b/src/main/resources/dictionary/haskell.dic
@@ -5,6 +5,7 @@ compat
 datatype
 decl
 decls
+deepseq
 deserialize
 deserializer
 deserializing
@@ -43,6 +44,7 @@ peano
 pprint
 prog
 safecopy
+seq
 sqlite
 stderr
 stdin

--- a/src/main/scala/intellij/haskell/spellchecker/CabalSpellcheckingStrategy.scala
+++ b/src/main/scala/intellij/haskell/spellchecker/CabalSpellcheckingStrategy.scala
@@ -8,10 +8,5 @@ import intellij.haskell.cabal.CabalLanguage
   * Provide spellchecker support for Cabal sources.
   */
 class CabalSpellcheckingStrategy extends SpellcheckingStrategy {
-  // Use TEXT_TOKENIZER so prime' names won't be marked as a typo.
-  override def getTokenizer(element: PsiElement): Tokenizer[_ <: PsiElement] = {
-    SpellcheckingStrategy.TEXT_TOKENIZER
-  }
-
   override def isMyContext(element: PsiElement): Boolean = CabalLanguage.Instance.is(element.getLanguage)
 }

--- a/src/main/scala/intellij/haskell/spellchecker/HaskellSpellcheckingStrategy.scala
+++ b/src/main/scala/intellij/haskell/spellchecker/HaskellSpellcheckingStrategy.scala
@@ -8,10 +8,5 @@ import com.intellij.spellchecker.tokenizer.{Tokenizer, SpellcheckingStrategy}
  * Provide spellchecker support for Haskell sources.
  */
 class HaskellSpellcheckingStrategy extends SpellcheckingStrategy {
-  // Use TEXT_TOKENIZER so prime' names won't be marked as a typo.
-  override def getTokenizer(element: PsiElement): Tokenizer[_ <: PsiElement] = {
-    SpellcheckingStrategy.TEXT_TOKENIZER
-  }
-
   override def isMyContext(element: PsiElement): Boolean = HaskellLanguage.Instance.is(element.getLanguage)
 }


### PR DESCRIPTION
Fixes #109.

Also adding `deepseq` and `seq` to the spellchecker dictionary.