### PR TITLE
Optimize downloading library sources

### DIFF
--- a/src/main/scala/intellij/haskell/module/HaskellModuleBuilder.scala
+++ b/src/main/scala/intellij/haskell/module/HaskellModuleBuilder.scala
@@ -231,8 +231,8 @@ object HaskellModuleBuilder {
 
     haskellPackages.filter(packageInfo => {
       new File(project.getBasePath + File.separator + LibName + File.separator + packageInfo.dirName).exists()
-    }) ++ haskellPackages.filter(packageInfo => {
-      !new File(project.getBasePath + File.separator + LibName + File.separator + packageInfo.dirName).exists()
+    }) ++ haskellPackages.filterNot(packageInfo => {
+      new File(project.getBasePath + File.separator + LibName + File.separator + packageInfo.dirName).exists()
     }).flatMap { packageInfo =>
       val stdErr = CommandLine.runProgram(Some(project), project.getBasePath + File.separator + LibName, stackPath, Seq("unpack", packageInfo.dirName), 10000, captureOutputToLog = true, logErrorAsInfo = true).map(_.getStderr)
       progressFraction = progressFraction + step

--- a/src/main/scala/intellij/haskell/module/HaskellModuleBuilder.scala
+++ b/src/main/scala/intellij/haskell/module/HaskellModuleBuilder.scala
@@ -229,9 +229,10 @@ object HaskellModuleBuilder {
 
     libRoot.listFiles().filterNot(subDir => haskellPackages.map(_.dirName).contains(subDir.getName)).foreach(FileUtil.delete)
 
-    haskellPackages.filter(packageInfo => {
+    val alreadyDownloadedPackages = haskellPackages.filter(packageInfo => {
       new File(project.getBasePath + File.separator + LibName + File.separator + packageInfo.dirName).exists()
-    }) ++ haskellPackages.filterNot(packageInfo => {
+    })
+    val newDownloadedPackages = haskellPackages.filterNot(packageInfo => {
       new File(project.getBasePath + File.separator + LibName + File.separator + packageInfo.dirName).exists()
     }).flatMap { packageInfo =>
       val stdErr = CommandLine.runProgram(Some(project), project.getBasePath + File.separator + LibName, stackPath, Seq("unpack", packageInfo.dirName), 10000, captureOutputToLog = true, logErrorAsInfo = true).map(_.getStderr)
@@ -244,6 +245,7 @@ object HaskellModuleBuilder {
         Seq(packageInfo)
       }
     }
+    alreadyDownloadedPackages ++ newDownloadedPackages
   }
 
   private def getUrlByPath(path: String): String = {

--- a/src/main/scala/intellij/haskell/module/HaskellModuleBuilder.scala
+++ b/src/main/scala/intellij/haskell/module/HaskellModuleBuilder.scala
@@ -186,8 +186,9 @@ object HaskellModuleBuilder {
       ProgressManager.getInstance().run(new Task.Backgroundable(project, "Downloading Haskell library sources and adding them as source libraries to module") {
         def run(progressIndicator: ProgressIndicator) {
           val libDirectory = getIdeaHaskellLibDirectory(project)
-          FileUtil.delete(libDirectory)
-          FileUtil.createDirectory(libDirectory)
+          if (!FileUtil.exists(getIdeaHaskellLibDirectoryStr(project))) {
+            FileUtil.createDirectory(libDirectory)
+          }
           StackCommandLine.runCommand(Seq("list-dependencies", "--test"), project, timeoutInMillis = 60.seconds.toMillis).map(_.getStdoutLines).foreach(dependencyLines => {
             val packageName = HaskellProjectUtil.findCabalPackageName(project)
             val packages = getPackages(project, dependencyLines.asScala).filterNot(p => packageName.contains(p.name))
@@ -203,6 +204,10 @@ object HaskellModuleBuilder {
 
   private def getIdeaHaskellLibDirectory(project: Project): File = {
     new File(project.getBasePath, LibName)
+  }
+
+  private def getIdeaHaskellLibDirectoryStr(project: Project): String = {
+    project.getBasePath + File.separator + LibName
   }
 
   private def getPackages(project: Project, dependencyLines: Seq[String]): Seq[HaskellPackageInfo] = {


### PR DESCRIPTION
Since #135 is taking redownloading library sources into consideration, so remove the library root directory and download all library sources is not a good idea anymore, it will cost user extra time to wait for the downloading process if there is a bunch of dependencies.

This PR handles two things

* Delete library sources which are no longer as dependencies of the project.
* Just download library sources which are not downloaded before.