### PR TITLE
Eliminate hoogle error log

### DIFF
--- a/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
@@ -72,7 +72,7 @@ object HoogleComponent {
     ApplicationManager.getApplication.executeOnPooledThread(new Runnable {
       override def run(): Unit = {
         try {
-          StackCommandLine.runCommand(Seq("hoogle", "--rebuild"), project, timeoutInMillis = 10.minutes.toMillis, logErrorAsInfo = true)
+          StackCommandLine.runCommand(Seq("hoogle", "--rebuild"), project, timeoutInMillis = 10.minutes.toMillis, logErrorAsInfo = true, captureOutputToLog = true)
         } finally {
           hoogleAvailable = true
         }


### PR DESCRIPTION
Fixes #157.

Actually, maybe this is a hoogle upstream issue because it will treat these output below as stderr.

<img width="559" alt="screen shot 2017-02-26 at 3 57 08 pm" src="https://cloud.githubusercontent.com/assets/6234553/23338148/4f8b4b44-fc3d-11e6-85aa-3785bbd65619.png">

So we should avoid it in order to make sure it will not introduce any confusions for users.