### PR TITLE
Fix stylish-haskell only format action

### DIFF
--- a/intellij-haskell/META-INF/plugin.xml
+++ b/intellij-haskell/META-INF/plugin.xml
@@ -402,7 +402,7 @@
             </action>
 
             <action id="Haskell.StylishHaskellFormat"
-                    class="intellij.haskell.action.HaskellFormatAction"
+                    class="intellij.haskell.action.StylishHaskellFormatAction"
                     text="Reformat Code with Stylish-haskell"
                     description="Format current file with stylish-haskell">
                 <keyboard-shortcut first-keystroke="ctrl alt u" keymap="$default"/>


### PR DESCRIPTION
Behavior of `Ctrl+Alt+U` hotkey was the same as the `Ctrl+Alt+;` - `hindent` was called anyway before `stylish-haskell`. It was due to bug (probably copy-paste error) in `plugin.xml`. This PR fixes behavior of `Ctrl+Alt+U` hotkey by calling appropriate format action.