### PR TITLE
Add "sticky" type info action

### DIFF
--- a/intellij-haskell/META-INF/plugin.xml
+++ b/intellij-haskell/META-INF/plugin.xml
@@ -341,6 +341,13 @@
                 <keyboard-shortcut first-keystroke="ctrl alt p" keymap="Mac OS X 10.5+"/>
             </action>
 
+            <action id="Haskell.ShowTypeSticky" class="intellij.haskell.action.ShowTypeStickyAction"
+                    text="Show Type (Sticky)" description="Show type of (selected) expression">
+
+                <keyboard-shortcut first-keystroke="ctrl alt i" keymap="Mac OS X"/>
+                <keyboard-shortcut first-keystroke="ctrl alt i" keymap="Mac OS X 10.5+"/>
+            </action>
+
             <action id="Haskell.ShowInfo" class="intellij.haskell.action.ShowNameInfoAction"
                     text="Show Info" description="Show info about identifier in context of file">
 

--- a/src/main/scala/intellij/haskell/action/ShowTypeAction.scala
+++ b/src/main/scala/intellij/haskell/action/ShowTypeAction.scala
@@ -18,11 +18,12 @@ package intellij.haskell.action
 
 import com.intellij.openapi.actionSystem.{AnAction, AnActionEvent}
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.{Editor, SelectionModel}
+import com.intellij.openapi.project.Project
 import com.intellij.psi.{PsiElement, PsiFile}
 import intellij.haskell.editor.HaskellCompletionContributor
 import intellij.haskell.external.component.{HaskellComponentsManager, StackProjectManager}
-import intellij.haskell.psi.HaskellPsiUtil
+import intellij.haskell.psi._
 import intellij.haskell.util.{HaskellEditorUtil, StringUtil, TypeInfoUtil}
 
 class ShowTypeAction extends AnAction {
@@ -35,49 +36,62 @@ class ShowTypeAction extends AnAction {
     ActionUtil.findActionContext(actionEvent).foreach(actionContext => {
       val editor = actionContext.editor
       val psiFile = actionContext.psiFile
-      val selectionModel = actionContext.selectionModel
-      selectionModel match {
+
+      actionContext.selectionModel match {
         case Some(sm) => HaskellComponentsManager.findTypeInfoForSelection(psiFile, sm) match {
           case Some(ti) => HaskellEditorUtil.showHint(editor, StringUtil.escapeString(ti.typeSignature))
           case None => HaskellEditorUtil.showHint(editor, "Could not determine type for selection")
         }
         case _ => Option(psiFile.findElementAt(editor.getCaretModel.getOffset)).foreach { psiElement =>
-
-          if (!StackProjectManager.isBuilding(actionContext.project)) {
-            ApplicationManager.getApplication.executeOnPooledThread(new Runnable {
-              override def run(): Unit = {
-                TypeInfoUtil.preloadTypesAround(psiElement)
-              }
-            })
-          }
-
-          HaskellComponentsManager.findTypeInfoForElement(psiElement, forceGetInfo = true) match {
-            case Some(ti) => HaskellEditorUtil.showHint(editor, StringUtil.escapeString(ti.typeSignature))
-            case None if HaskellPsiUtil.findExpressionParent(psiElement).isDefined =>
-              val moduleNames = HaskellPsiUtil.findImportDeclarations(psiFile).flatMap(_.getModuleName)
-              val declaration = HaskellPsiUtil.findQualifiedNameParent(psiElement).flatMap(qualifiedNameElement => {
-                val name = qualifiedNameElement.getName
-                HaskellCompletionContributor.getAvailableImportedModuleIdentifiers(psiFile).find(mi => moduleNames.exists(_ == mi.moduleName) && mi.name == name).map(_.declaration).
-                  orElse(findModuleName(psiFile).flatMap(mn => HaskellComponentsManager.findExportedModuleIdentifiersOfCurrentFile(psiFile, mn).find(_.name == name).map(_.declaration))).
-                  orElse(HaskellPsiUtil.findHaskellDeclarationElements(psiFile).find(_.getIdentifierElements.exists(_.getName == name)).map(_.getText.replaceAll("""\s+""", " ")))
-              })
-
-              declaration match {
-                case Some(d) => HaskellEditorUtil.showHint(editor, d)
-                case None => showNoTypeInfoHint(editor, psiElement)
-              }
-            case None => showNoTypeInfoHint(editor, psiElement)
-          }
+          ShowTypeAction.showTypeHint(actionContext.project, editor, psiElement, psiFile)
         }
       }
     })
   }
 
-  private def findModuleName(psiFile: PsiFile) = {
+}
+
+object ShowTypeAction {
+  def showTypeSelectionHint(editor: Editor, psiFile: PsiFile, selectionModel: SelectionModel): Unit = {
+    HaskellComponentsManager.findTypeInfoForSelection(psiFile, selectionModel) match {
+      case Some(ti) => HaskellEditorUtil.showHint(editor, StringUtil.escapeString(ti.typeSignature))
+      case None => HaskellEditorUtil.showHint(editor, "Could not determine type for selection")
+    }
+  }
+
+  def showTypeHint(project: Project, editor: Editor, psiElement: PsiElement, psiFile: PsiFile, sticky: Boolean = false): Unit = {
+    if (!StackProjectManager.isBuilding(project)) {
+      ApplicationManager.getApplication.executeOnPooledThread(new Runnable {
+        override def run(): Unit = {
+          TypeInfoUtil.preloadTypesAround(psiElement)
+        }
+      })
+    }
+
+    HaskellComponentsManager.findTypeInfoForElement(psiElement, forceGetInfo = true) match {
+      case Some(ti) => HaskellEditorUtil.showHint(editor, StringUtil.escapeString(ti.typeSignature), sticky)
+      case None if HaskellPsiUtil.findExpressionParent(psiElement).isDefined =>
+        val moduleNames = HaskellPsiUtil.findImportDeclarations(psiFile).flatMap(_.getModuleName)
+        val declaration = HaskellPsiUtil.findQualifiedNameParent(psiElement).flatMap(qualifiedNameElement => {
+          val name = qualifiedNameElement.getName
+          HaskellCompletionContributor.getAvailableImportedModuleIdentifiers(psiFile).find(mi => moduleNames.exists(_ == mi.moduleName) && mi.name == name).map(_.declaration).
+            orElse(findModuleName(psiFile).flatMap(mn => HaskellComponentsManager.findExportedModuleIdentifiersOfCurrentFile(psiFile, mn).find(_.name == name).map(_.declaration))).
+            orElse(HaskellPsiUtil.findHaskellDeclarationElements(psiFile).find(_.getIdentifierElements.exists(_.getName == name)).map(_.getText.replaceAll("""\s+""", " ")))
+        })
+
+        declaration match {
+          case Some(d) => HaskellEditorUtil.showHint(editor, d, sticky)
+          case None => showNoTypeInfoHint(editor, psiElement)
+        }
+      case None => showNoTypeInfoHint(editor, psiElement)
+    }
+  }
+
+  private def findModuleName(psiFile: PsiFile): Option[String] = {
     HaskellPsiUtil.findModuleName(psiFile, runInRead = true)
   }
 
-  private def showNoTypeInfoHint(editor: Editor, psiElement: PsiElement) = {
+  private def showNoTypeInfoHint(editor: Editor, psiElement: PsiElement): Unit = {
     HaskellEditorUtil.showHint(editor, s"Could not determine type for ${StringUtil.escapeString(psiElement.getText)}")
   }
 }

--- a/src/main/scala/intellij/haskell/action/ShowTypeStickyAction.scala
+++ b/src/main/scala/intellij/haskell/action/ShowTypeStickyAction.scala
@@ -1,0 +1,63 @@
+package intellij.haskell.action
+
+import com.intellij.openapi.actionSystem.{AnAction, AnActionEvent}
+import com.intellij.psi.{PsiElement, TokenType}
+import com.intellij.psi.util.PsiTreeUtil
+import intellij.haskell.external.component.HaskellComponentsManager
+import intellij.haskell.psi.{HaskellPsiUtil, HaskellQualifiedNameElement, HaskellTypes}
+import intellij.haskell.util.{HaskellEditorUtil, StringUtil}
+
+import scala.annotation.tailrec
+
+class ShowTypeStickyAction extends AnAction {
+
+  override def update(actionEvent: AnActionEvent) {
+    HaskellEditorUtil.enableAction(onlyForProjectFile = true, actionEvent)
+  }
+
+  def actionPerformed(actionEvent: AnActionEvent) {
+    ActionUtil.findActionContext(actionEvent).foreach(actionContext => {
+      val editor = actionContext.editor
+      val psiFile = actionContext.psiFile
+
+      actionContext.selectionModel match {
+        case Some(sm) => HaskellComponentsManager.findTypeInfoForSelection(psiFile, sm) match {
+          case Some(ti) => HaskellEditorUtil.showHint(editor, StringUtil.escapeString(ti.typeSignature), sticky = true)
+          case None => HaskellEditorUtil.showHint(editor, "Could not determine type for selection")
+        }
+        case _ =>
+          for {
+            psiElement <- untilNonWhitespaceBackwards(Option(psiFile.findElementAt(editor.getCaretModel.getOffset)))
+            namedElement <- HaskellPsiUtil.findNamedElement(psiElement).orElse {
+              untilNameElementBackwards(Some(PsiTreeUtil.getDeepestLast(psiElement)))
+            }
+          } yield {
+            ShowTypeAction.showTypeHint(actionContext.project, editor, namedElement, psiFile, sticky = true)
+          }
+      }
+    })
+  }
+
+  @tailrec
+  private def untilNonWhitespaceBackwards(element: Option[PsiElement]): Option[PsiElement] = {
+    element match {
+      case Some(e) if e.getNode.getElementType == HaskellTypes.HS_NEWLINE || e.getNode.getElementType == TokenType.WHITE_SPACE =>
+        untilNonWhitespaceBackwards(Option(e.getPrevSibling))
+      case e => e
+    }
+  }
+
+  @tailrec
+  private def untilNameElementBackwards(element: Option[PsiElement]): Option[HaskellQualifiedNameElement] = {
+    element match {
+      case Some(e) =>
+        HaskellPsiUtil.findQualifiedNameElement(e) match {
+          case None => untilNameElementBackwards(Option(e.getPrevSibling))
+          case qualifiedName => qualifiedName
+        }
+
+      case None => None
+    }
+  }
+
+}

--- a/src/main/scala/intellij/haskell/psi/HaskellPsiUtil.scala
+++ b/src/main/scala/intellij/haskell/psi/HaskellPsiUtil.scala
@@ -46,6 +46,13 @@ object HaskellPsiUtil {
     }
   }
 
+  def findQualifiedNameElement(psiElement: PsiElement): Option[HaskellQualifiedNameElement] = {
+    psiElement match {
+      case e: HaskellQualifiedNameElement => Some(e)
+      case e => Option(PsiTreeUtil.findFirstParent(e, QualifiedNameElementCondition)).map(_.asInstanceOf[HaskellQualifiedNameElement])
+    }
+  }
+
   def findModIdElement(psiElement: PsiElement): Option[HaskellModid] = {
     psiElement match {
       case e: HaskellModid => Some(e)

--- a/src/main/scala/intellij/haskell/util/HaskellEditorUtil.scala
+++ b/src/main/scala/intellij/haskell/util/HaskellEditorUtil.scala
@@ -81,7 +81,7 @@ object HaskellEditorUtil {
     }
   }
 
-  def showHint(editor: Editor, text: String): Unit = {
+  def showHint(editor: Editor, text: String, sticky: Boolean = false): Unit = {
     val label = HintUtil.createInformationLabel(text)
     label.setFont(UIUtil.getLabelFont)
 
@@ -96,9 +96,15 @@ object HaskellEditorUtil {
 
     val position = editor.getCaretModel.getLogicalPosition
     val point = HintManagerImpl.getHintPosition(hint, editor, position, HintManager.ABOVE)
+    val hintHint = HintManagerImpl.createHintHint(editor, point, hint, HintManager.ABOVE).setExplicitClose(sticky)
 
-    hintManager.showEditorHint(hint, editor, point,
-      HintManager.HIDE_BY_ANY_KEY | HintManager.HIDE_BY_TEXT_CHANGE | HintManager.HIDE_BY_SCROLLING, 0, false)
+    val hideFlags = if (sticky) {
+      HintManager.HIDE_BY_ESCAPE
+    } else {
+      HintManager.HIDE_BY_ANY_KEY | HintManager.HIDE_BY_TEXT_CHANGE | HintManager.HIDE_BY_SCROLLING
+    }
+
+    hintManager.showEditorHint(hint, editor, point, hideFlags, 0, false, hintHint)
   }
 
   def showInfoMessageBalloon(message: String, editor: Editor, inCenterOfEditor: Boolean): Unit = {


### PR DESCRIPTION
This is my attempt to add "sticky" Show Type Info as discussed in #199. Feel free to change the name. I didn't know what else to call it.

I tried to re-use already existing helper methods as much as I could, but I might have missed some. Particularly the whitespace handling was a little tricky because those nodes are on a different branch of the tree, so I had to "re-enter" the expression. I suspect there's a better way to do that, but I couldn't find anything to help me with that.

I'm sure this can be improved over time with better heuristics, but I kept the initial implementation simple for now.