### PR TITLE
Clean Hoogle output for documentation

### DIFF
--- a/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
@@ -56,7 +56,9 @@ object HoogleComponent {
           if (processOutput.getStdoutLines.isEmpty || processOutput.getStdout.contains("No results found")) {
             None
           } else {
-            Option(processOutput.getStdout).map(o => s"${Pattern.compile("$", Pattern.MULTILINE).matcher(o).replaceAll("<br>").replace(" ", "&nbsp;")}")
+            // Remove excessive newlines that Hoogle outputs
+            val cleanOutput = processOutput.getStdout.trim.replaceAll("\n{3,}", "\n\n")
+            Some(s"${Pattern.compile("$", Pattern.MULTILINE).matcher(cleanOutput).replaceAll("<br>").replace(" ", "&nbsp;")}")
           }
         )
     } else {


### PR DESCRIPTION
Hoogle outputs excessive newlines in many cases (3 or more). For example, if you run `hoogle -i catMaybes` you should see what I'm referring to.

I think this occurs because Hoogle cleans up html tags, but doesn't touch up all the newlines that this leaves behind?

Anyway, here is a quick fix for that.

Also, `getStdout` is NotNull, so I removed the unnecessary null check.