### PR TITLE
Add multi-line REPL support

### DIFF
--- a/src/main/resources/ghci/8.2.1.ghci
+++ b/src/main/resources/ghci/8.2.1.ghci
@@ -1,3 +1,3 @@
 :set +m
 :set prompt ""
-:set prompt2 ""
+:set prompt-cont ""

--- a/src/main/resources/ghci/default.ghci
+++ b/src/main/resources/ghci/default.ghci
@@ -1,0 +1,6 @@
+:set +m
+:set prompt ""
+:set prompt2 ""
+
+-- GHC 8.2.1+
+:set prompt-cont ""

--- a/src/main/scala/intellij/haskell/runconfig/console/HaskellConsoleState.scala
+++ b/src/main/scala/intellij/haskell/runconfig/console/HaskellConsoleState.scala
@@ -24,8 +24,9 @@ class HaskellConsoleState(val configuration: HaskellConsoleConfiguration, val en
     HaskellSdkType.getStackPath(project) match {
       case Some(stackPath) =>
         val stackTarget = configuration.getStackTarget
+        val ghciOptionsPath = getClass.getResource("/ghci/default.ghci").getPath
         val commandLine = new GeneralCommandLine(stackPath)
-          .withParameters(configuration.replCommand)
+          .withParameters(configuration.replCommand, "--ghci-options", s"-ignore-dot-ghci -ghci-script $ghciOptionsPath")
           .withWorkDirectory(project.getBasePath)
 
         if (stackTarget.nonEmpty) {

--- a/src/main/scala/intellij/haskell/runconfig/console/HaskellConsoleView.scala
+++ b/src/main/scala/intellij/haskell/runconfig/console/HaskellConsoleView.scala
@@ -15,18 +15,16 @@
  */
 package intellij.haskell.runconfig.console
 
-import java.io.{IOException, OutputStreamWriter}
-
 import com.intellij.execution.console.{ConsoleHistoryController, ConsoleRootType, LanguageConsoleImpl}
 import com.intellij.execution.filters._
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.project.{Project, ProjectManager}
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiFile
 import com.intellij.util.DocumentUtil
-import intellij.haskell.{HaskellFileType, HaskellNotificationGroup}
+import intellij.haskell.HaskellFileType
 
 object HaskellConsoleView {
   private val HaskellConsoleKey: Key[HaskellConsoleInfo] = Key.create("HASKELL CONSOLE KEY")

--- a/src/main/scala/intellij/haskell/runconfig/console/HaskellConsoleView.scala
+++ b/src/main/scala/intellij/haskell/runconfig/console/HaskellConsoleView.scala
@@ -41,8 +41,7 @@ object HaskellConsoleView {
 class HaskellConsoleView(val project: Project, val configuration: HaskellConsoleConfiguration) extends LanguageConsoleImpl(project, "Haskell Stack REPL", HaskellFileType.Instance.getLanguage) {
 
   private val consoleRootType = new ConsoleRootType("haskell", "Haskell") {}
-  private var historyController: ConsoleHistoryController = _
-  private var outputStreamWriter: OutputStreamWriter = _
+  private val historyController: ConsoleHistoryController = new ConsoleHistoryController(consoleRootType, "haskell", this)
   private var lastCommand: Option[String] = None
 
   addMessageFilter(createFileHyperLinkFilter())
@@ -53,12 +52,9 @@ class HaskellConsoleView(val project: Project, val configuration: HaskellConsole
 
   override def attachToProcess(processHandler: ProcessHandler): Unit = {
     super.attachToProcess(processHandler)
-    Option(processHandler.getProcessInput).foreach(processInput => {
-      outputStreamWriter = new OutputStreamWriter(processInput)
-      historyController = new ConsoleHistoryController(consoleRootType, "haskell", this)
-      historyController.install()
-      HaskellConsoleViewMap.addConsole(this)
-    })
+
+    historyController.install()
+    HaskellConsoleViewMap.addConsole(this)
   }
 
   override def dispose() {
@@ -85,9 +81,10 @@ class HaskellConsoleView(val project: Project, val configuration: HaskellConsole
     executeCommand(text)
   }
 
-  def executeCommand(command: String, addToHistory: Boolean = true, echo: Boolean = true): Unit = {
+  def executeCommand(rawCommandText: String, addToHistory: Boolean = true): Unit = {
+    val command = rawCommandText.trim()
+
     for {
-      processInputWriter <- Option(outputStreamWriter)
       historyController <- Option(historyController)
     } yield {
       if (addToHistory) {
@@ -95,18 +92,13 @@ class HaskellConsoleView(val project: Project, val configuration: HaskellConsole
         historyController.addToHistory(command)
       }
 
-      if (echo) {
-        print(command + "\n", ConsoleViewContentType.NORMAL_OUTPUT)
+      val commandInputText = command match {
+        // In order to execute multi-line commands in +m mode, 2 newlines are required.
+        case s if s.contains('\n') => s + "\n\n"
+        case s => s + "\n"
       }
 
-      for (line <- command.split("\n")) {
-        try {
-          processInputWriter.write(line + "\n")
-          processInputWriter.flush()
-        } catch {
-          case e: IOException => HaskellNotificationGroup.logErrorEvent(ProjectManager.getInstance().getDefaultProject, e.getMessage)
-        }
-      }
+      print(commandInputText, ConsoleViewContentType.USER_INPUT)
     }
   }
 


### PR DESCRIPTION
Fixes #212 

Some notes about the implementation so far:

- `prompt2` looks like it was renamed to `prompt-cont` in GHC 8.2.1. To get rid of that `Some flags have not been recognized: prompt2,` warning, I guess I would need to create 2 separate GHCi config files.
- Rather than use a GHCi config file, it would be nice if I could set them with plain CLI flags (or environment variables)... but I couldn't find any such options in GHCi. It looks like the only choices are to use a config file, or send each command one by one after the REPL starts (like ":set +m", ":set prompt ...", and so on).

After some thinking, I'm actually thinking the latter is better, because that way I only override the relevant options and don't mess with any other custom settings a user has in their `.ghci` file. Because I really don't want to override *all* user ghci settings. I only want to change the problematic ones for IntelliJ.