### PR TITLE
Use OS-specific directory for peristent data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
 val sprayJson = "io.spray" %% "spray-json" % "1.3.4"
 val snakeYaml = "org.yaml" % "snakeyaml" % "1.19"
 val scaffeine = "com.github.blemale" %% "scaffeine" % "2.5.0"
+val directories = "io.github.soc" % "directories" % "10"
 
 lazy val intellijHaskell = (project in file(".")).
   enablePlugins(SbtIdeaPlugin).
@@ -19,6 +20,7 @@ lazy val intellijHaskell = (project in file(".")).
     libraryDependencies += sprayJson,
     libraryDependencies += snakeYaml,
     libraryDependencies += scaffeine,
+    libraryDependencies += directories,
     unmanagedSourceDirectories in Compile += baseDirectory.value / "gen"
   )
 

--- a/src/main/scala/intellij/haskell/GlobalInfo.scala
+++ b/src/main/scala/intellij/haskell/GlobalInfo.scala
@@ -6,6 +6,7 @@ import java.nio.file.{Path, Paths}
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VfsUtil
+import io.github.soc.directories.ProjectDirectories
 import intellij.haskell.util.HaskellFileUtil
 
 object GlobalInfo {
@@ -17,15 +18,23 @@ object GlobalInfo {
 
   private final val IntelliJHaskellDirName = ".intellij-haskell"
 
+  private final val IntelliJHaskellDirectories = ProjectDirectories.from("com.github", "rikvdkleij", "intellij-haskell")
+
   def getIntelliJHaskellDirectory: File = {
     val homeDirectory = HaskellFileUtil.getAbsolutePath(VfsUtil.getUserHomeDir)
-    val directory = new File(homeDirectory, IntelliJHaskellDirName)
-    if (directory.exists()) {
-      HaskellFileUtil.removeGroupWritePermission(directory)
+    val dotDirectory = new File(homeDirectory, IntelliJHaskellDirName)
+    if (dotDirectory.exists()) {
+      HaskellFileUtil.removeGroupWritePermission(dotDirectory)
+      dotDirectory
     } else {
-      HaskellFileUtil.createDirectoryIfNotExists(directory, onlyWriteableByOwner = true)
+      val directory = new File(IntelliJHaskellDirectories.cacheDir)
+      if (directory.exists()) {
+        HaskellFileUtil.removeGroupWritePermission(directory)
+      } else {
+        HaskellFileUtil.createDirectoryIfNotExists(directory, onlyWriteableByOwner = true)
+      }
+      directory
     }
-    directory
   }
 
   def getLibrarySourcesPath: String = {


### PR DESCRIPTION
Implements #315. This will prefer and keep using an existing `~/.intellij-haskell` so that existing installations will not be affected. First run in a clean system will choose `cacheDir` using [soc/directories-jvm](https://github.com/soc/directories-jvm#basedirectories).

I can add a note to README if you think it’s worth mentioning?