### PR TITLE
Add soft keyword annotator

### DIFF
--- a/intellij-haskell/META-INF/plugin.xml
+++ b/intellij-haskell/META-INF/plugin.xml
@@ -272,6 +272,8 @@
         <!-- Annotator -->
         <externalAnnotator language="Haskell"
                            implementationClass="intellij.haskell.annotator.HaskellAnnotator"/>
+        <annotator language="Haskell"
+                   implementationClass="intellij.haskell.highlighter.HaskellSoftKeywordsAnnotator"/>
         <annotator language="Cabal"
                    implementationClass="intellij.haskell.cabal.highlighting.CabalAnnotator"/>
 

--- a/src/main/scala/intellij/haskell/highlighter/HaskellSoftKeywordsAnnotator.scala
+++ b/src/main/scala/intellij/haskell/highlighter/HaskellSoftKeywordsAnnotator.scala
@@ -1,0 +1,19 @@
+package intellij.haskell.highlighter
+
+import com.intellij.lang.annotation.{AnnotationHolder, Annotator}
+import com.intellij.psi.PsiElement
+import intellij.haskell.psi.{HaskellImportHiding, HaskellImportQualified, HaskellImportQualifiedAs}
+
+class HaskellSoftKeywordsAnnotator extends Annotator {
+  override def annotate(element: PsiElement, holder: AnnotationHolder): Unit = {
+    element match {
+      case _: HaskellImportQualified => holder.createInfoAnnotation(element, null)
+        .setTextAttributes(HaskellSyntaxHighlighter.Keyword)
+      case _: HaskellImportQualifiedAs => holder.createInfoAnnotation(element.getFirstChild, null)
+        .setTextAttributes(HaskellSyntaxHighlighter.Keyword)
+      case _: HaskellImportHiding => holder.createInfoAnnotation(element, null)
+        .setTextAttributes(HaskellSyntaxHighlighter.Keyword)
+      case _ =>
+    }
+  }
+}


### PR DESCRIPTION
[intellij-haskell.zip](https://github.com/rikvdkleij/intellij-haskell/files/2609634/intellij-haskell.zip)

Addressing comments from https://github.com/rikvdkleij/intellij-haskell/issues/329#issuecomment-441117025

Highlighting `as`, `hiding` and `qualified` as keywords.