### PR TITLE
Layout lexer: getting something very basic to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ idea/
 out/
 project/project/
 jflex-*.jar
+intellij-haskell.zip

--- a/gen/intellij/haskell/parser/HaskellParser.java
+++ b/gen/intellij/haskell/parser/HaskellParser.java
@@ -7,6 +7,7 @@ import com.intellij.lang.PsiBuilder;
 import com.intellij.lang.PsiBuilder.Marker;
 import com.intellij.lang.PsiParser;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.IFileElementType;
 
 import static intellij.haskell.psi.HaskellParserUtil.*;
 import static intellij.haskell.psi.HaskellTypes.*;
@@ -23,180 +24,10 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         boolean r;
         b = adapt_builder_(t, b, this, null);
         Marker m = enter_section_(b, 0, _COLLAPSE_, null);
-        if (t == HS_CCONTEXT) {
-            r = ccontext(b, 0);
-        } else if (t == HS_CDECL_DATA_DECLARATION) {
-            r = cdecl_data_declaration(b, 0);
-        } else if (t == HS_CDECLS) {
-            r = cdecls(b, 0);
-        } else if (t == HS_CIDECLS) {
-            r = cidecls(b, 0);
-        } else if (t == HS_CLASS_DECLARATION) {
-            r = class_declaration(b, 0);
-        } else if (t == HS_CLAZZ) {
-            r = clazz(b, 0);
-        } else if (t == HS_CNAME) {
-            r = cname(b, 0);
-        } else if (t == HS_CNAME_DOT_DOT) {
-            r = cname_dot_dot(b, 0);
-        } else if (t == HS_COMMENTS) {
-            r = comments(b, 0);
-        } else if (t == HS_CON) {
-            r = con(b, 0);
-        } else if (t == HS_CONID) {
-            r = conid(b, 0);
-        } else if (t == HS_CONOP) {
-            r = conop(b, 0);
-        } else if (t == HS_CONSTR) {
-            r = constr(b, 0);
-        } else if (t == HS_CONSTR_1) {
-            r = constr1(b, 0);
-        } else if (t == HS_CONSTR_2) {
-            r = constr2(b, 0);
-        } else if (t == HS_CONSTR_3) {
-            r = constr3(b, 0);
-        } else if (t == HS_CONSYM) {
-            r = consym(b, 0);
-        } else if (t == HS_DATA_DECLARATION) {
-            r = data_declaration(b, 0);
-        } else if (t == HS_DATA_DECLARATION_DERIVING) {
-            r = data_declaration_deriving(b, 0);
-        } else if (t == HS_DEFAULT_DECLARATION) {
-            r = default_declaration(b, 0);
-        } else if (t == HS_DERIVING_DECLARATION) {
-            r = deriving_declaration(b, 0);
-        } else if (t == HS_DOT_DOT) {
-            r = dot_dot(b, 0);
-        } else if (t == HS_EXPORT) {
-            r = export(b, 0);
-        } else if (t == HS_EXPORTS) {
-            r = exports(b, 0);
-        } else if (t == HS_EXPRESSION) {
-            r = expression(b, 0);
-        } else if (t == HS_FIELDDECL) {
-            r = fielddecl(b, 0);
-        } else if (t == HS_FILE_HEADER) {
-            r = file_header(b, 0);
-        } else if (t == HS_FIXITY_DECLARATION) {
-            r = fixity_declaration(b, 0);
-        } else if (t == HS_FOREIGN_DECLARATION) {
-            r = foreign_declaration(b, 0);
-        } else if (t == HS_GENERAL_PRAGMA_CONTENT) {
-            r = general_pragma_content(b, 0);
-        } else if (t == HS_GTYCON) {
-            r = gtycon(b, 0);
-        } else if (t == HS_IMPORT_DECLARATION) {
-            r = import_declaration(b, 0);
-        } else if (t == HS_IMPORT_DECLARATIONS) {
-            r = import_declarations(b, 0);
-        } else if (t == HS_IMPORT_EMPTY_SPEC) {
-            r = import_empty_spec(b, 0);
-        } else if (t == HS_IMPORT_HIDING) {
-            r = import_hiding(b, 0);
-        } else if (t == HS_IMPORT_HIDING_SPEC) {
-            r = import_hiding_spec(b, 0);
-        } else if (t == HS_IMPORT_ID) {
-            r = import_id(b, 0);
-        } else if (t == HS_IMPORT_IDS_SPEC) {
-            r = import_ids_spec(b, 0);
-        } else if (t == HS_IMPORT_PACKAGE_NAME) {
-            r = import_package_name(b, 0);
-        } else if (t == HS_IMPORT_QUALIFIED) {
-            r = import_qualified(b, 0);
-        } else if (t == HS_IMPORT_QUALIFIED_AS) {
-            r = import_qualified_as(b, 0);
-        } else if (t == HS_IMPORT_SPEC) {
-            r = import_spec(b, 0);
-        } else if (t == HS_INST) {
-            r = inst(b, 0);
-        } else if (t == HS_INSTANCE_DECLARATION) {
-            r = instance_declaration(b, 0);
-        } else if (t == HS_INSTVAR) {
-            r = instvar(b, 0);
-        } else if (t == HS_KIND_SIGNATURE) {
-            r = kind_signature(b, 0);
-        } else if (t == HS_LIST_TYPE) {
-            r = list_type(b, 0);
-        } else if (t == HS_MODID) {
-            r = modid(b, 0);
-        } else if (t == HS_MODULE_BODY) {
-            r = module_body(b, 0);
-        } else if (t == HS_MODULE_DECLARATION) {
-            r = module_declaration(b, 0);
-        } else if (t == HS_NEWCONSTR) {
-            r = newconstr(b, 0);
-        } else if (t == HS_NEWCONSTR_FIELDDECL) {
-            r = newconstr_fielddecl(b, 0);
-        } else if (t == HS_NEWTYPE_DECLARATION) {
-            r = newtype_declaration(b, 0);
-        } else if (t == HS_PRAGMA) {
-            r = pragma(b, 0);
-        } else if (t == HS_Q_CON) {
-            r = q_con(b, 0);
-        } else if (t == HS_Q_CON_QUALIFIER) {
-            r = q_con_qualifier(b, 0);
-        } else if (t == HS_Q_CON_QUALIFIER_1) {
-            r = q_con_qualifier1(b, 0);
-        } else if (t == HS_Q_CON_QUALIFIER_2) {
-            r = q_con_qualifier2(b, 0);
-        } else if (t == HS_Q_CON_QUALIFIER_3) {
-            r = q_con_qualifier3(b, 0);
-        } else if (t == HS_Q_CON_QUALIFIER_4) {
-            r = q_con_qualifier4(b, 0);
-        } else if (t == HS_Q_NAME) {
-            r = q_name(b, 0);
-        } else if (t == HS_Q_NAMES) {
-            r = q_names(b, 0);
-        } else if (t == HS_Q_VAR_CON) {
-            r = q_var_con(b, 0);
-        } else if (t == HS_QUALIFIER) {
-            r = qualifier(b, 0);
-        } else if (t == HS_RESERVED_ID) {
-            r = reserved_id(b, 0);
-        } else if (t == HS_SCONTEXT) {
-            r = scontext(b, 0);
-        } else if (t == HS_SHEBANG_LINE) {
-            r = shebang_line(b, 0);
-        } else if (t == HS_SIMPLECLASS) {
-            r = simpleclass(b, 0);
-        } else if (t == HS_SIMPLETYPE) {
-            r = simpletype(b, 0);
-        } else if (t == HS_TEXT_LITERAL) {
-            r = text_literal(b, 0);
-        } else if (t == HS_TOP_DECLARATION) {
-            r = top_declaration(b, 0);
-        } else if (t == HS_TOP_DECLARATION_LINE) {
-            r = top_declaration_line(b, 0);
-        } else if (t == HS_TTYPE) {
-            r = ttype(b, 0);
-        } else if (t == HS_TTYPE_1) {
-            r = ttype1(b, 0);
-        } else if (t == HS_TTYPE_2) {
-            r = ttype2(b, 0);
-        } else if (t == HS_TYPE_DECLARATION) {
-            r = type_declaration(b, 0);
-        } else if (t == HS_TYPE_EQUALITY) {
-            r = type_equality(b, 0);
-        } else if (t == HS_TYPE_FAMILY_DECLARATION) {
-            r = type_family_declaration(b, 0);
-        } else if (t == HS_TYPE_FAMILY_TYPE) {
-            r = type_family_type(b, 0);
-        } else if (t == HS_TYPE_INSTANCE_DECLARATION) {
-            r = type_instance_declaration(b, 0);
-        } else if (t == HS_TYPE_SIGNATURE) {
-            r = type_signature(b, 0);
-        } else if (t == HS_VAR) {
-            r = var(b, 0);
-        } else if (t == HS_VAR_CON) {
-            r = var_con(b, 0);
-        } else if (t == HS_VARID) {
-            r = varid(b, 0);
-        } else if (t == HS_VAROP) {
-            r = varop(b, 0);
-        } else if (t == HS_VARSYM) {
-            r = varsym(b, 0);
-        } else {
+        if (t instanceof IFileElementType) {
             r = parse_root_(t, b, 0);
+        } else {
+            r = false;
         }
         exit_section_(b, 0, m, t, r, true, TRUE_CONDITION);
     }
@@ -4209,18 +4040,73 @@ public class HaskellParser implements PsiParser, LightPsiParser {
     }
 
     /* ********************************************************** */
-    // general_id+
+    // LET LEFT_BRACE let_definitions* RIGHT_BRACE? IN expression
+    public static boolean let_abstraction(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "let_abstraction")) return false;
+        if (!nextTokenIs(b, HS_LET)) return false;
+        boolean r;
+        Marker m = enter_section_(b);
+        r = consumeTokens(b, 0, HS_LET, HS_LEFT_BRACE);
+        r = r && let_abstraction_2(b, l + 1);
+        r = r && let_abstraction_3(b, l + 1);
+        r = r && consumeToken(b, HS_IN);
+        r = r && expression(b, l + 1);
+        exit_section_(b, m, HS_LET_ABSTRACTION, r);
+        return r;
+    }
+
+    // let_definitions*
+    private static boolean let_abstraction_2(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "let_abstraction_2")) return false;
+        while (true) {
+            int c = current_position_(b);
+            if (!let_definitions(b, l + 1)) break;
+            if (!empty_element_parsed_guard_(b, "let_abstraction_2", c)) break;
+        }
+        return true;
+    }
+
+    // RIGHT_BRACE?
+    private static boolean let_abstraction_3(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "let_abstraction_3")) return false;
+        consumeToken(b, HS_RIGHT_BRACE);
+        return true;
+    }
+
+    /* ********************************************************** */
+    // expression SEMICOLON
+    static boolean let_definitions(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "let_definitions")) return false;
+        boolean r;
+        Marker m = enter_section_(b);
+        r = expression(b, l + 1);
+        r = r && consumeToken(b, HS_SEMICOLON);
+        exit_section_(b, m, null, r);
+        return r;
+    }
+
+    /* ********************************************************** */
+    // (general_id | let_abstraction)+
     static boolean line_expression(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "line_expression")) return false;
         boolean r;
         Marker m = enter_section_(b);
-        r = general_id(b, l + 1);
+        r = line_expression_0(b, l + 1);
         while (r) {
             int c = current_position_(b);
-            if (!general_id(b, l + 1)) break;
+            if (!line_expression_0(b, l + 1)) break;
             if (!empty_element_parsed_guard_(b, "line_expression", c)) break;
         }
         exit_section_(b, m, null, r);
+        return r;
+    }
+
+    // general_id | let_abstraction
+    private static boolean line_expression_0(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "line_expression_0")) return false;
+        boolean r;
+        r = general_id(b, l + 1);
+        if (!r) r = let_abstraction(b, l + 1);
         return r;
     }
 
@@ -4332,7 +4218,7 @@ public class HaskellParser implements PsiParser, LightPsiParser {
     }
 
     /* ********************************************************** */
-    // MODULE modid onl pragma? onl (exports onl)? WHERE
+    // MODULE modid onl pragma? onl (exports onl)? where_clause
     public static boolean module_declaration(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "module_declaration")) return false;
         if (!nextTokenIs(b, HS_MODULE)) return false;
@@ -4344,7 +4230,7 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         r = r && module_declaration_3(b, l + 1);
         r = r && onl(b, l + 1);
         r = r && module_declaration_5(b, l + 1);
-        r = r && consumeToken(b, HS_WHERE);
+        r = r && where_clause(b, l + 1);
         exit_section_(b, m, HS_MODULE_DECLARATION, r);
         return r;
     }
@@ -5076,7 +4962,7 @@ public class HaskellParser implements PsiParser, LightPsiParser {
     }
 
     /* ********************************************************** */
-    // CASE | CLASS | DATA | DEFAULT | DERIVING | DO | ELSE | IF | IMPORT | IN | INSTANCE | LET | MODULE | NEWTYPE | OF | THEN | TYPE | WHERE | UNDERSCORE
+    // CASE | CLASS | DATA | DEFAULT | DERIVING | DO | ELSE | IF | IMPORT | INSTANCE | MODULE | NEWTYPE | OF | THEN | TYPE | WHERE | UNDERSCORE
     public static boolean reserved_id(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "reserved_id")) return false;
         boolean r;
@@ -5090,9 +4976,7 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         if (!r) r = consumeToken(b, HS_ELSE);
         if (!r) r = consumeToken(b, HS_IF);
         if (!r) r = consumeToken(b, HS_IMPORT);
-        if (!r) r = consumeToken(b, HS_IN);
         if (!r) r = consumeToken(b, HS_INSTANCE);
-        if (!r) r = consumeToken(b, HS_LET);
         if (!r) r = consumeToken(b, HS_MODULE);
         if (!r) r = consumeToken(b, HS_NEWTYPE);
         if (!r) r = consumeToken(b, HS_OF);
@@ -5496,14 +5380,14 @@ public class HaskellParser implements PsiParser, LightPsiParser {
     }
 
     /* ********************************************************** */
-    // top_declaration SEMICOLON? NEWLINE
+    // top_declaration SEMICOLON? NEWLINE?
     public static boolean top_declaration_line(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "top_declaration_line")) return false;
         boolean r;
         Marker m = enter_section_(b, l, _NONE_, HS_TOP_DECLARATION_LINE, "<top declaration line>");
         r = top_declaration(b, l + 1);
         r = r && top_declaration_line_1(b, l + 1);
-        r = r && consumeToken(b, HS_NEWLINE);
+        r = r && top_declaration_line_2(b, l + 1);
         exit_section_(b, l, m, r, false, null);
         return r;
     }
@@ -5515,8 +5399,15 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         return true;
     }
 
+    // NEWLINE?
+    private static boolean top_declaration_line_2(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "top_declaration_line_2")) return false;
+        consumeToken(b, HS_NEWLINE);
+        return true;
+    }
+
     /* ********************************************************** */
-    // (top_declaration_line (NEWLINE | DIRECTIVE)*)* top_declaration?
+    // (top_declaration_line (SEMICOLON | DIRECTIVE)*)* top_declaration?
     static boolean top_declarations(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "top_declarations")) return false;
         boolean r;
@@ -5527,7 +5418,7 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         return r;
     }
 
-    // (top_declaration_line (NEWLINE | DIRECTIVE)*)*
+    // (top_declaration_line (SEMICOLON | DIRECTIVE)*)*
     private static boolean top_declarations_0(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "top_declarations_0")) return false;
         while (true) {
@@ -5538,7 +5429,7 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         return true;
     }
 
-    // top_declaration_line (NEWLINE | DIRECTIVE)*
+    // top_declaration_line (SEMICOLON | DIRECTIVE)*
     private static boolean top_declarations_0_0(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "top_declarations_0_0")) return false;
         boolean r;
@@ -5549,7 +5440,7 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         return r;
     }
 
-    // (NEWLINE | DIRECTIVE)*
+    // (SEMICOLON | DIRECTIVE)*
     private static boolean top_declarations_0_0_1(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "top_declarations_0_0_1")) return false;
         while (true) {
@@ -5560,11 +5451,11 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         return true;
     }
 
-    // NEWLINE | DIRECTIVE
+    // SEMICOLON | DIRECTIVE
     private static boolean top_declarations_0_0_1_0(PsiBuilder b, int l) {
         if (!recursion_guard_(b, l, "top_declarations_0_0_1_0")) return false;
         boolean r;
-        r = consumeToken(b, HS_NEWLINE);
+        r = consumeToken(b, HS_SEMICOLON);
         if (!r) r = consumeToken(b, HS_DIRECTIVE);
         return r;
     }
@@ -6637,6 +6528,28 @@ public class HaskellParser implements PsiParser, LightPsiParser {
         }
         exit_section_(b, m, null, r);
         return r;
+    }
+
+    /* ********************************************************** */
+    // WHERE LEFT_BRACE top_declarations RIGHT_BRACE?
+    public static boolean where_clause(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "where_clause")) return false;
+        if (!nextTokenIs(b, HS_WHERE)) return false;
+        boolean r, p;
+        Marker m = enter_section_(b, l, _NONE_, HS_WHERE_CLAUSE, null);
+        r = consumeTokens(b, 1, HS_WHERE, HS_LEFT_BRACE);
+        p = r; // pin = 1
+        r = r && report_error_(b, top_declarations(b, l + 1));
+        r = p && where_clause_3(b, l + 1) && r;
+        exit_section_(b, l, m, r, p, null);
+        return r || p;
+    }
+
+    // RIGHT_BRACE?
+    private static boolean where_clause_3(PsiBuilder b, int l) {
+        if (!recursion_guard_(b, l, "where_clause_3")) return false;
+        consumeToken(b, HS_RIGHT_BRACE);
+        return true;
     }
 
 }

--- a/gen/intellij/haskell/psi/HaskellCdecls.java
+++ b/gen/intellij/haskell/psi/HaskellCdecls.java
@@ -23,6 +23,9 @@ public interface HaskellCdecls extends HaskellCompositeElement {
     List<HaskellInstanceDeclaration> getInstanceDeclarationList();
 
     @NotNull
+    List<HaskellLetAbstraction> getLetAbstractionList();
+
+    @NotNull
     List<HaskellNewtypeDeclaration> getNewtypeDeclarationList();
 
     @NotNull

--- a/gen/intellij/haskell/psi/HaskellCidecls.java
+++ b/gen/intellij/haskell/psi/HaskellCidecls.java
@@ -20,6 +20,9 @@ public interface HaskellCidecls extends HaskellCompositeElement {
     List<HaskellInstanceDeclaration> getInstanceDeclarationList();
 
     @NotNull
+    List<HaskellLetAbstraction> getLetAbstractionList();
+
+    @NotNull
     List<HaskellNewtypeDeclaration> getNewtypeDeclarationList();
 
     @NotNull

--- a/gen/intellij/haskell/psi/HaskellExpression.java
+++ b/gen/intellij/haskell/psi/HaskellExpression.java
@@ -11,6 +11,9 @@ public interface HaskellExpression extends HaskellExpressionElement {
     List<HaskellDotDot> getDotDotList();
 
     @NotNull
+    List<HaskellLetAbstraction> getLetAbstractionList();
+
+    @NotNull
     List<HaskellPragma> getPragmaList();
 
     @NotNull

--- a/gen/intellij/haskell/psi/HaskellLetAbstraction.java
+++ b/gen/intellij/haskell/psi/HaskellLetAbstraction.java
@@ -1,0 +1,13 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface HaskellLetAbstraction extends HaskellCompositeElement {
+
+  @NotNull
+  List<HaskellExpression> getExpressionList();
+
+}

--- a/gen/intellij/haskell/psi/HaskellModuleBody.java
+++ b/gen/intellij/haskell/psi/HaskellModuleBody.java
@@ -2,22 +2,10 @@
 package intellij.haskell.psi;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 public interface HaskellModuleBody extends HaskellCompositeElement {
 
     @NotNull
-    HaskellImportDeclarations getImportDeclarations();
-
-    @Nullable
     HaskellModuleDeclaration getModuleDeclaration();
-
-    @Nullable
-    HaskellTopDeclaration getTopDeclaration();
-
-    @NotNull
-    List<HaskellTopDeclarationLine> getTopDeclarationLineList();
 
 }

--- a/gen/intellij/haskell/psi/HaskellModuleDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellModuleDeclaration.java
@@ -18,6 +18,9 @@ public interface HaskellModuleDeclaration extends HaskellDeclarationElement {
     @Nullable
     HaskellPragma getPragma();
 
+    @NotNull
+    HaskellWhereClause getWhereClause();
+
     String getName();
 
     ItemPresentation getPresentation();

--- a/gen/intellij/haskell/psi/HaskellTypes.java
+++ b/gen/intellij/haskell/psi/HaskellTypes.java
@@ -54,6 +54,7 @@ public interface HaskellTypes {
     IElementType HS_INSTANCE_DECLARATION = new HaskellCompositeElementType("HS_INSTANCE_DECLARATION");
     IElementType HS_INSTVAR = new HaskellCompositeElementType("HS_INSTVAR");
     IElementType HS_KIND_SIGNATURE = new HaskellCompositeElementType("HS_KIND_SIGNATURE");
+    IElementType HS_LET_ABSTRACTION = new HaskellCompositeElementType("HS_LET_ABSTRACTION");
     IElementType HS_LIST_TYPE = new HaskellCompositeElementType("HS_LIST_TYPE");
     IElementType HS_MODID = HaskellElementTypeFactory.factory("HS_MODID");
     IElementType HS_MODULE_BODY = new HaskellCompositeElementType("HS_MODULE_BODY");
@@ -94,6 +95,7 @@ public interface HaskellTypes {
     IElementType HS_VAROP = new HaskellCompositeElementType("HS_VAROP");
     IElementType HS_VARSYM = HaskellElementTypeFactory.factory("HS_VARSYM");
     IElementType HS_VAR_CON = new HaskellCompositeElementType("HS_VAR_CON");
+    IElementType HS_WHERE_CLAUSE = new HaskellCompositeElementType("HS_WHERE_CLAUSE");
 
     IElementType HS_AT = new HaskellTokenType("AT");
     IElementType HS_BACKQUOTE = new HaskellTokenType("BACKQUOTE");
@@ -263,6 +265,8 @@ public interface HaskellTypes {
                 return new HaskellInstvarImpl(node);
             } else if (type == HS_KIND_SIGNATURE) {
                 return new HaskellKindSignatureImpl(node);
+            } else if (type == HS_LET_ABSTRACTION) {
+                return new HaskellLetAbstractionImpl(node);
             } else if (type == HS_LIST_TYPE) {
                 return new HaskellListTypeImpl(node);
             } else if (type == HS_MODID) {
@@ -343,6 +347,8 @@ public interface HaskellTypes {
                 return new HaskellVarsymImpl(node);
             } else if (type == HS_VAR_CON) {
                 return new HaskellVarConImpl(node);
+            } else if (type == HS_WHERE_CLAUSE) {
+                return new HaskellWhereClauseImpl(node);
             }
             throw new AssertionError("Unknown element type: " + type);
         }

--- a/gen/intellij/haskell/psi/HaskellVisitor.java
+++ b/gen/intellij/haskell/psi/HaskellVisitor.java
@@ -191,6 +191,10 @@ public class HaskellVisitor extends PsiElementVisitor {
         visitCompositeElement(o);
     }
 
+    public void visitLetAbstraction(@NotNull HaskellLetAbstraction o) {
+        visitCompositeElement(o);
+    }
+
     public void visitListType(@NotNull HaskellListType o) {
         visitCompositeElement(o);
     }
@@ -355,6 +359,10 @@ public class HaskellVisitor extends PsiElementVisitor {
 
     public void visitVarsym(@NotNull HaskellVarsym o) {
         visitNamedElement(o);
+    }
+
+    public void visitWhereClause(@NotNull HaskellWhereClause o) {
+        visitCompositeElement(o);
     }
 
     public void visitCNameElement(@NotNull HaskellCNameElement o) {

--- a/gen/intellij/haskell/psi/HaskellWhereClause.java
+++ b/gen/intellij/haskell/psi/HaskellWhereClause.java
@@ -1,13 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellWhereClause extends HaskellCompositeElement {
 
-  @Nullable
+    @Nullable
+    HaskellImportDeclarations getImportDeclarations();
+
+    @Nullable
   HaskellTopDeclaration getTopDeclaration();
 
   @NotNull

--- a/gen/intellij/haskell/psi/HaskellWhereClause.java
+++ b/gen/intellij/haskell/psi/HaskellWhereClause.java
@@ -1,0 +1,16 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface HaskellWhereClause extends HaskellCompositeElement {
+
+  @Nullable
+  HaskellTopDeclaration getTopDeclaration();
+
+  @NotNull
+  List<HaskellTopDeclarationLine> getTopDeclarationLineList();
+
+}

--- a/gen/intellij/haskell/psi/impl/HaskellCdeclsImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellCdeclsImpl.java
@@ -56,6 +56,12 @@ public class HaskellCdeclsImpl extends HaskellCompositeElementImpl implements Ha
 
     @Override
     @NotNull
+    public List<HaskellLetAbstraction> getLetAbstractionList() {
+        return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellLetAbstraction.class);
+    }
+
+    @Override
+    @NotNull
     public List<HaskellNewtypeDeclaration> getNewtypeDeclarationList() {
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellNewtypeDeclaration.class);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellCideclsImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellCideclsImpl.java
@@ -50,6 +50,12 @@ public class HaskellCideclsImpl extends HaskellCompositeElementImpl implements H
 
     @Override
     @NotNull
+    public List<HaskellLetAbstraction> getLetAbstractionList() {
+        return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellLetAbstraction.class);
+    }
+
+    @Override
+    @NotNull
     public List<HaskellNewtypeDeclaration> getNewtypeDeclarationList() {
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellNewtypeDeclaration.class);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellClassDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellClassDeclarationImpl.java
@@ -52,18 +52,22 @@ public class HaskellClassDeclarationImpl extends HaskellCompositeElementImpl imp
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellTtype.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
     public Seq<HaskellNamedElement> getIdentifierElements() {
         return HaskellPsiImplUtil.getIdentifierElements(this);
     }
 
+    @Override
     public Option<String> getModuleName() {
         return HaskellPsiImplUtil.getModuleName(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellCnameImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellCnameImpl.java
@@ -48,14 +48,17 @@ public class HaskellCnameImpl extends HaskellCompositeElementImpl implements Has
         return PsiTreeUtil.getChildOfType(this, HaskellVarop.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public HaskellNamedElement getIdentifierElement() {
         return HaskellPsiImplUtil.getIdentifierElement(this);
     }
 
+    @Override
     public Option<String> getQualifierName() {
         return HaskellPsiImplUtil.getQualifierName(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellCon;
+import intellij.haskell.psi.HaskellConid;
+import intellij.haskell.psi.HaskellConsym;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellConImpl extends HaskellCNameElementImpl implements HaskellCon {
 
@@ -37,8 +38,9 @@ public class HaskellConImpl extends HaskellCNameElementImpl implements HaskellCo
     return PsiTreeUtil.getChildOfType(this, HaskellConsym.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConImpl.java
@@ -38,9 +38,9 @@ public class HaskellConImpl extends HaskellCNameElementImpl implements HaskellCo
     return PsiTreeUtil.getChildOfType(this, HaskellConsym.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellConidImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConidImpl.java
@@ -32,22 +32,27 @@ public class HaskellConidImpl extends HaskellNamedStubBasedPsiElementBase<Haskel
         else super.accept(visitor);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellConidImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConidImpl.java
@@ -57,4 +57,9 @@ public class HaskellConidImpl extends HaskellNamedStubBasedPsiElementBase<Haskel
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
+    public String toString() {
+        return HaskellPsiImplUtil.toString(this);
+    }
+
 }

--- a/gen/intellij/haskell/psi/impl/HaskellConopImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConopImpl.java
@@ -38,9 +38,9 @@ public class HaskellConopImpl extends HaskellCNameElementImpl implements Haskell
     return PsiTreeUtil.getChildOfType(this, HaskellConsym.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellConopImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConopImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellConid;
+import intellij.haskell.psi.HaskellConop;
+import intellij.haskell.psi.HaskellConsym;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellConopImpl extends HaskellCNameElementImpl implements HaskellConop {
 
@@ -37,8 +38,9 @@ public class HaskellConopImpl extends HaskellCNameElementImpl implements Haskell
     return PsiTreeUtil.getChildOfType(this, HaskellConsym.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellConsymImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConsymImpl.java
@@ -32,22 +32,27 @@ public class HaskellConsymImpl extends HaskellNamedStubBasedPsiElementBase<Haske
         else super.accept(visitor);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellDataDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDataDeclarationImpl.java
@@ -82,22 +82,27 @@ public class HaskellDataDeclarationImpl extends HaskellCompositeElementImpl impl
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellTypeSignature.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
     public Seq<HaskellNamedElement> getIdentifierElements() {
         return HaskellPsiImplUtil.getIdentifierElements(this);
     }
 
+    @Override
     public Option<String> getModuleName() {
         return HaskellPsiImplUtil.getModuleName(this);
     }
 
+    @Override
     public HaskellNamedElement getDataTypeConstructor() {
         return HaskellPsiImplUtil.getDataTypeConstructor(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellDefaultDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDefaultDeclarationImpl.java
@@ -40,24 +40,24 @@ public class HaskellDefaultDeclarationImpl extends HaskellCompositeElementImpl i
     return PsiTreeUtil.getChildOfType(this, HaskellTypeSignature.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public ItemPresentation getPresentation() {
-        return HaskellPsiImplUtil.getPresentation(this);
-    }
+  @Override
+  public ItemPresentation getPresentation() {
+    return HaskellPsiImplUtil.getPresentation(this);
+  }
 
-    @Override
-    public Seq<HaskellNamedElement> getIdentifierElements() {
-        return HaskellPsiImplUtil.getIdentifierElements(this);
-    }
+  @Override
+  public Seq<HaskellNamedElement> getIdentifierElements() {
+    return HaskellPsiImplUtil.getIdentifierElements(this);
+  }
 
-    @Override
-    public Option<String> getModuleName() {
-        return HaskellPsiImplUtil.getModuleName(this);
-    }
+  @Override
+  public Option<String> getModuleName() {
+    return HaskellPsiImplUtil.getModuleName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellDefaultDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDefaultDeclarationImpl.java
@@ -1,17 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
-import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
+
+import java.util.List;
 
 public class HaskellDefaultDeclarationImpl extends HaskellCompositeElementImpl implements HaskellDefaultDeclaration {
 
@@ -40,20 +40,24 @@ public class HaskellDefaultDeclarationImpl extends HaskellCompositeElementImpl i
     return PsiTreeUtil.getChildOfType(this, HaskellTypeSignature.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public ItemPresentation getPresentation() {
-    return HaskellPsiImplUtil.getPresentation(this);
-  }
+    @Override
+    public ItemPresentation getPresentation() {
+        return HaskellPsiImplUtil.getPresentation(this);
+    }
 
-  public Seq<HaskellNamedElement> getIdentifierElements() {
-    return HaskellPsiImplUtil.getIdentifierElements(this);
-  }
+    @Override
+    public Seq<HaskellNamedElement> getIdentifierElements() {
+        return HaskellPsiImplUtil.getIdentifierElements(this);
+    }
 
-  public Option<String> getModuleName() {
-    return HaskellPsiImplUtil.getModuleName(this);
-  }
+    @Override
+    public Option<String> getModuleName() {
+        return HaskellPsiImplUtil.getModuleName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellDerivingDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDerivingDeclarationImpl.java
@@ -1,15 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
-import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
 
@@ -46,20 +44,24 @@ public class HaskellDerivingDeclarationImpl extends HaskellCompositeElementImpl 
     return PsiTreeUtil.getChildOfType(this, HaskellScontext.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public ItemPresentation getPresentation() {
-    return HaskellPsiImplUtil.getPresentation(this);
-  }
+    @Override
+    public ItemPresentation getPresentation() {
+        return HaskellPsiImplUtil.getPresentation(this);
+    }
 
-  public Seq<HaskellNamedElement> getIdentifierElements() {
-    return HaskellPsiImplUtil.getIdentifierElements(this);
-  }
+    @Override
+    public Seq<HaskellNamedElement> getIdentifierElements() {
+        return HaskellPsiImplUtil.getIdentifierElements(this);
+    }
 
-  public Option<String> getModuleName() {
-    return HaskellPsiImplUtil.getModuleName(this);
-  }
+    @Override
+    public Option<String> getModuleName() {
+        return HaskellPsiImplUtil.getModuleName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellDerivingDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDerivingDeclarationImpl.java
@@ -44,24 +44,24 @@ public class HaskellDerivingDeclarationImpl extends HaskellCompositeElementImpl 
     return PsiTreeUtil.getChildOfType(this, HaskellScontext.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public ItemPresentation getPresentation() {
-        return HaskellPsiImplUtil.getPresentation(this);
-    }
+  @Override
+  public ItemPresentation getPresentation() {
+    return HaskellPsiImplUtil.getPresentation(this);
+  }
 
-    @Override
-    public Seq<HaskellNamedElement> getIdentifierElements() {
-        return HaskellPsiImplUtil.getIdentifierElements(this);
-    }
+  @Override
+  public Seq<HaskellNamedElement> getIdentifierElements() {
+    return HaskellPsiImplUtil.getIdentifierElements(this);
+  }
 
-    @Override
-    public Option<String> getModuleName() {
-        return HaskellPsiImplUtil.getModuleName(this);
-    }
+  @Override
+  public Option<String> getModuleName() {
+    return HaskellPsiImplUtil.getModuleName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellExpressionImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellExpressionImpl.java
@@ -32,6 +32,12 @@ public class HaskellExpressionImpl extends HaskellExpressionElementImpl implemen
 
     @Override
     @NotNull
+    public List<HaskellLetAbstraction> getLetAbstractionList() {
+        return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellLetAbstraction.class);
+    }
+
+    @Override
+    @NotNull
     public List<HaskellPragma> getPragmaList() {
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellPragma.class);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellForeignDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellForeignDeclarationImpl.java
@@ -1,15 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
-import com.intellij.navigation.ItemPresentation;
+import intellij.haskell.psi.HaskellExpression;
+import intellij.haskell.psi.HaskellForeignDeclaration;
+import intellij.haskell.psi.HaskellNamedElement;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 import scala.Option;
 import scala.collection.Seq;
 
@@ -34,20 +34,24 @@ public class HaskellForeignDeclarationImpl extends HaskellCompositeElementImpl i
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellExpression.class));
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public ItemPresentation getPresentation() {
-    return HaskellPsiImplUtil.getPresentation(this);
-  }
+    @Override
+    public ItemPresentation getPresentation() {
+        return HaskellPsiImplUtil.getPresentation(this);
+    }
 
-  public Seq<HaskellNamedElement> getIdentifierElements() {
-    return HaskellPsiImplUtil.getIdentifierElements(this);
-  }
+    @Override
+    public Seq<HaskellNamedElement> getIdentifierElements() {
+        return HaskellPsiImplUtil.getIdentifierElements(this);
+    }
 
-  public Option<String> getModuleName() {
-    return HaskellPsiImplUtil.getModuleName(this);
-  }
+    @Override
+    public Option<String> getModuleName() {
+        return HaskellPsiImplUtil.getModuleName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellForeignDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellForeignDeclarationImpl.java
@@ -34,24 +34,24 @@ public class HaskellForeignDeclarationImpl extends HaskellCompositeElementImpl i
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellExpression.class));
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public ItemPresentation getPresentation() {
-        return HaskellPsiImplUtil.getPresentation(this);
-    }
+  @Override
+  public ItemPresentation getPresentation() {
+    return HaskellPsiImplUtil.getPresentation(this);
+  }
 
-    @Override
-    public Seq<HaskellNamedElement> getIdentifierElements() {
-        return HaskellPsiImplUtil.getIdentifierElements(this);
-    }
+  @Override
+  public Seq<HaskellNamedElement> getIdentifierElements() {
+    return HaskellPsiImplUtil.getIdentifierElements(this);
+  }
 
-    @Override
-    public Option<String> getModuleName() {
-        return HaskellPsiImplUtil.getModuleName(this);
-    }
+  @Override
+  public Option<String> getModuleName() {
+    return HaskellPsiImplUtil.getModuleName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellImportDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportDeclarationImpl.java
@@ -60,6 +60,7 @@ public class HaskellImportDeclarationImpl extends HaskellCompositeElementImpl im
         return PsiTreeUtil.getChildOfType(this, HaskellPragma.class);
     }
 
+    @Override
     public Option<String> getModuleName() {
         return HaskellPsiImplUtil.getModuleName(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellInstanceDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellInstanceDeclarationImpl.java
@@ -70,18 +70,22 @@ public class HaskellInstanceDeclarationImpl extends HaskellCompositeElementImpl 
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellVarCon.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
     public Seq<HaskellNamedElement> getIdentifierElements() {
         return HaskellPsiImplUtil.getIdentifierElements(this);
     }
 
+    @Override
     public Option<String> getModuleName() {
         return HaskellPsiImplUtil.getModuleName(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellLetAbstractionImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellLetAbstractionImpl.java
@@ -1,0 +1,34 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static intellij.haskell.psi.HaskellTypes.*;
+import intellij.haskell.psi.*;
+
+public class HaskellLetAbstractionImpl extends HaskellCompositeElementImpl implements HaskellLetAbstraction {
+
+  public HaskellLetAbstractionImpl(ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull HaskellVisitor visitor) {
+    visitor.visitLetAbstraction(this);
+  }
+
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public List<HaskellExpression> getExpressionList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellExpression.class);
+  }
+
+}

--- a/gen/intellij/haskell/psi/impl/HaskellModidImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellModidImpl.java
@@ -42,22 +42,27 @@ public class HaskellModidImpl extends HaskellNamedStubBasedPsiElementBase<Haskel
         return PsiTreeUtil.getStubChildrenOfTypeAsList(this, HaskellConid.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellModidImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellModidImpl.java
@@ -67,4 +67,9 @@ public class HaskellModidImpl extends HaskellNamedStubBasedPsiElementBase<Haskel
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
+    public String toString() {
+        return HaskellPsiImplUtil.toString(this);
+    }
+
 }

--- a/gen/intellij/haskell/psi/impl/HaskellModuleBodyImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellModuleBodyImpl.java
@@ -4,11 +4,10 @@ package intellij.haskell.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellModuleBody;
+import intellij.haskell.psi.HaskellModuleDeclaration;
+import intellij.haskell.psi.HaskellVisitor;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 public class HaskellModuleBodyImpl extends HaskellCompositeElementImpl implements HaskellModuleBody {
 
@@ -27,26 +26,8 @@ public class HaskellModuleBodyImpl extends HaskellCompositeElementImpl implement
 
     @Override
     @NotNull
-    public HaskellImportDeclarations getImportDeclarations() {
-        return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellImportDeclarations.class));
-    }
-
-    @Override
-    @Nullable
     public HaskellModuleDeclaration getModuleDeclaration() {
-        return PsiTreeUtil.getChildOfType(this, HaskellModuleDeclaration.class);
-    }
-
-    @Override
-    @Nullable
-    public HaskellTopDeclaration getTopDeclaration() {
-        return PsiTreeUtil.getChildOfType(this, HaskellTopDeclaration.class);
-    }
-
-    @Override
-    @NotNull
-    public List<HaskellTopDeclarationLine> getTopDeclarationLineList() {
-        return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellTopDeclarationLine.class);
+        return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellModuleDeclaration.class));
     }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellModuleDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellModuleDeclarationImpl.java
@@ -44,18 +44,28 @@ public class HaskellModuleDeclarationImpl extends HaskellCompositeElementImpl im
         return PsiTreeUtil.getChildOfType(this, HaskellPragma.class);
     }
 
+    @Override
+    @NotNull
+    public HaskellWhereClause getWhereClause() {
+        return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellWhereClause.class));
+    }
+
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
     public Seq<HaskellNamedElement> getIdentifierElements() {
         return HaskellPsiImplUtil.getIdentifierElements(this);
     }
 
+    @Override
     public Option<String> getModuleName() {
         return HaskellPsiImplUtil.getModuleName(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellNewtypeDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellNewtypeDeclarationImpl.java
@@ -56,22 +56,27 @@ public class HaskellNewtypeDeclarationImpl extends HaskellCompositeElementImpl i
         return PsiTreeUtil.getChildOfType(this, HaskellTtype.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
     public Seq<HaskellNamedElement> getIdentifierElements() {
         return HaskellPsiImplUtil.getIdentifierElements(this);
     }
 
+    @Override
     public Option<String> getModuleName() {
         return HaskellPsiImplUtil.getModuleName(this);
     }
 
+    @Override
     public HaskellNamedElement getDataTypeConstructor() {
         return HaskellPsiImplUtil.getDataTypeConstructor(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellQConQualifier1Impl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQConQualifier1Impl.java
@@ -34,22 +34,27 @@ public class HaskellQConQualifier1Impl extends HaskellQualifierElementImpl imple
         return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellConid.class));
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellQConQualifier2Impl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQConQualifier2Impl.java
@@ -36,22 +36,27 @@ public class HaskellQConQualifier2Impl extends HaskellQualifierElementImpl imple
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellConid.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellQConQualifier3Impl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQConQualifier3Impl.java
@@ -36,22 +36,27 @@ public class HaskellQConQualifier3Impl extends HaskellQualifierElementImpl imple
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellConid.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellQConQualifier4Impl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQConQualifier4Impl.java
@@ -36,22 +36,27 @@ public class HaskellQConQualifier4Impl extends HaskellQualifierElementImpl imple
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellConid.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellQNameImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQNameImpl.java
@@ -36,14 +36,17 @@ public class HaskellQNameImpl extends HaskellCompositeElementImpl implements Has
         return PsiTreeUtil.getChildOfType(this, HaskellVarCon.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public HaskellNamedElement getIdentifierElement() {
         return HaskellPsiImplUtil.getIdentifierElement(this);
     }
 
+    @Override
     public Option<String> getQualifierName() {
         return HaskellPsiImplUtil.getQualifierName(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellQVarConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQVarConImpl.java
@@ -1,14 +1,12 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellQVarConImpl extends HaskellCompositeElementImpl implements HaskellQVarCon {
 
@@ -55,12 +53,14 @@ public class HaskellQVarConImpl extends HaskellCompositeElementImpl implements H
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public HaskellNamedElement getIdentifierElement() {
-    return HaskellPsiImplUtil.getIdentifierElement(this);
-  }
+    @Override
+    public HaskellNamedElement getIdentifierElement() {
+        return HaskellPsiImplUtil.getIdentifierElement(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellQVarConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQVarConImpl.java
@@ -53,14 +53,14 @@ public class HaskellQVarConImpl extends HaskellCompositeElementImpl implements H
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public HaskellNamedElement getIdentifierElement() {
-        return HaskellPsiImplUtil.getIdentifierElement(this);
-    }
+  @Override
+  public HaskellNamedElement getIdentifierElement() {
+    return HaskellPsiImplUtil.getIdentifierElement(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellQualifierImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQualifierImpl.java
@@ -36,22 +36,27 @@ public class HaskellQualifierImpl extends HaskellQualifierElementImpl implements
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellConid.class);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellSimpletypeImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellSimpletypeImpl.java
@@ -44,6 +44,7 @@ public class HaskellSimpletypeImpl extends HaskellCompositeElementImpl implement
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellTypeSignature.class);
     }
 
+    @Override
     public Seq<HaskellNamedElement> getIdentifierElements() {
         return HaskellPsiImplUtil.getIdentifierElements(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeDeclarationImpl.java
@@ -58,24 +58,24 @@ public class HaskellTypeDeclarationImpl extends HaskellCompositeElementImpl impl
     return PsiTreeUtil.getChildOfType(this, HaskellTypeSignature.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public ItemPresentation getPresentation() {
-        return HaskellPsiImplUtil.getPresentation(this);
-    }
+  @Override
+  public ItemPresentation getPresentation() {
+    return HaskellPsiImplUtil.getPresentation(this);
+  }
 
-    @Override
-    public Seq<HaskellNamedElement> getIdentifierElements() {
-        return HaskellPsiImplUtil.getIdentifierElements(this);
-    }
+  @Override
+  public Seq<HaskellNamedElement> getIdentifierElements() {
+    return HaskellPsiImplUtil.getIdentifierElements(this);
+  }
 
-    @Override
-    public Option<String> getModuleName() {
-        return HaskellPsiImplUtil.getModuleName(this);
-    }
+  @Override
+  public Option<String> getModuleName() {
+    return HaskellPsiImplUtil.getModuleName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeDeclarationImpl.java
@@ -1,17 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
-import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
+
+import java.util.List;
 
 public class HaskellTypeDeclarationImpl extends HaskellCompositeElementImpl implements HaskellTypeDeclaration {
 
@@ -58,20 +58,24 @@ public class HaskellTypeDeclarationImpl extends HaskellCompositeElementImpl impl
     return PsiTreeUtil.getChildOfType(this, HaskellTypeSignature.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public ItemPresentation getPresentation() {
-    return HaskellPsiImplUtil.getPresentation(this);
-  }
+    @Override
+    public ItemPresentation getPresentation() {
+        return HaskellPsiImplUtil.getPresentation(this);
+    }
 
-  public Seq<HaskellNamedElement> getIdentifierElements() {
-    return HaskellPsiImplUtil.getIdentifierElements(this);
-  }
+    @Override
+    public Seq<HaskellNamedElement> getIdentifierElements() {
+        return HaskellPsiImplUtil.getIdentifierElements(this);
+    }
 
-  public Option<String> getModuleName() {
-    return HaskellPsiImplUtil.getModuleName(this);
-  }
+    @Override
+    public Option<String> getModuleName() {
+        return HaskellPsiImplUtil.getModuleName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeFamilyDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeFamilyDeclarationImpl.java
@@ -38,24 +38,24 @@ public class HaskellTypeFamilyDeclarationImpl extends HaskellCompositeElementImp
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellTypeFamilyType.class));
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public ItemPresentation getPresentation() {
-        return HaskellPsiImplUtil.getPresentation(this);
-    }
+  @Override
+  public ItemPresentation getPresentation() {
+    return HaskellPsiImplUtil.getPresentation(this);
+  }
 
-    @Override
-    public Seq<HaskellNamedElement> getIdentifierElements() {
-        return HaskellPsiImplUtil.getIdentifierElements(this);
-    }
+  @Override
+  public Seq<HaskellNamedElement> getIdentifierElements() {
+    return HaskellPsiImplUtil.getIdentifierElements(this);
+  }
 
-    @Override
-    public Option<String> getModuleName() {
-        return HaskellPsiImplUtil.getModuleName(this);
-    }
+  @Override
+  public Option<String> getModuleName() {
+    return HaskellPsiImplUtil.getModuleName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeFamilyDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeFamilyDeclarationImpl.java
@@ -1,15 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
-import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
 
@@ -40,20 +38,24 @@ public class HaskellTypeFamilyDeclarationImpl extends HaskellCompositeElementImp
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellTypeFamilyType.class));
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public ItemPresentation getPresentation() {
-    return HaskellPsiImplUtil.getPresentation(this);
-  }
+    @Override
+    public ItemPresentation getPresentation() {
+        return HaskellPsiImplUtil.getPresentation(this);
+    }
 
-  public Seq<HaskellNamedElement> getIdentifierElements() {
-    return HaskellPsiImplUtil.getIdentifierElements(this);
-  }
+    @Override
+    public Seq<HaskellNamedElement> getIdentifierElements() {
+        return HaskellPsiImplUtil.getIdentifierElements(this);
+    }
 
-  public Option<String> getModuleName() {
-    return HaskellPsiImplUtil.getModuleName(this);
-  }
+    @Override
+    public Option<String> getModuleName() {
+        return HaskellPsiImplUtil.getModuleName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeInstanceDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeInstanceDeclarationImpl.java
@@ -1,15 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
-import com.intellij.navigation.ItemPresentation;
+import intellij.haskell.psi.HaskellExpression;
+import intellij.haskell.psi.HaskellNamedElement;
+import intellij.haskell.psi.HaskellTypeInstanceDeclaration;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 import scala.Option;
 import scala.collection.Seq;
 
@@ -34,20 +34,24 @@ public class HaskellTypeInstanceDeclarationImpl extends HaskellCompositeElementI
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellExpression.class));
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public ItemPresentation getPresentation() {
-    return HaskellPsiImplUtil.getPresentation(this);
-  }
+    @Override
+    public ItemPresentation getPresentation() {
+        return HaskellPsiImplUtil.getPresentation(this);
+    }
 
-  public Seq<HaskellNamedElement> getIdentifierElements() {
-    return HaskellPsiImplUtil.getIdentifierElements(this);
-  }
+    @Override
+    public Seq<HaskellNamedElement> getIdentifierElements() {
+        return HaskellPsiImplUtil.getIdentifierElements(this);
+    }
 
-  public Option<String> getModuleName() {
-    return HaskellPsiImplUtil.getModuleName(this);
-  }
+    @Override
+    public Option<String> getModuleName() {
+        return HaskellPsiImplUtil.getModuleName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeInstanceDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeInstanceDeclarationImpl.java
@@ -34,24 +34,24 @@ public class HaskellTypeInstanceDeclarationImpl extends HaskellCompositeElementI
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellExpression.class));
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public ItemPresentation getPresentation() {
-        return HaskellPsiImplUtil.getPresentation(this);
-    }
+  @Override
+  public ItemPresentation getPresentation() {
+    return HaskellPsiImplUtil.getPresentation(this);
+  }
 
-    @Override
-    public Seq<HaskellNamedElement> getIdentifierElements() {
-        return HaskellPsiImplUtil.getIdentifierElements(this);
-    }
+  @Override
+  public Seq<HaskellNamedElement> getIdentifierElements() {
+    return HaskellPsiImplUtil.getIdentifierElements(this);
+  }
 
-    @Override
-    public Option<String> getModuleName() {
-        return HaskellPsiImplUtil.getModuleName(this);
-    }
+  @Override
+  public Option<String> getModuleName() {
+    return HaskellPsiImplUtil.getModuleName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeSignatureImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeSignatureImpl.java
@@ -45,24 +45,24 @@ public class HaskellTypeSignatureImpl extends HaskellCompositeElementImpl implem
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellTtype.class));
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public ItemPresentation getPresentation() {
-        return HaskellPsiImplUtil.getPresentation(this);
-    }
+  @Override
+  public ItemPresentation getPresentation() {
+    return HaskellPsiImplUtil.getPresentation(this);
+  }
 
-    @Override
-    public Seq<HaskellNamedElement> getIdentifierElements() {
-        return HaskellPsiImplUtil.getIdentifierElements(this);
-    }
+  @Override
+  public Seq<HaskellNamedElement> getIdentifierElements() {
+    return HaskellPsiImplUtil.getIdentifierElements(this);
+  }
 
-    @Override
-    public Option<String> getModuleName() {
-        return HaskellPsiImplUtil.getModuleName(this);
-    }
+  @Override
+  public Option<String> getModuleName() {
+    return HaskellPsiImplUtil.getModuleName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellTypeSignatureImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeSignatureImpl.java
@@ -1,17 +1,16 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
-import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
 import scala.Option;
 import scala.collection.Seq;
+
+import java.util.List;
 
 public class HaskellTypeSignatureImpl extends HaskellCompositeElementImpl implements HaskellTypeSignature {
 
@@ -46,20 +45,24 @@ public class HaskellTypeSignatureImpl extends HaskellCompositeElementImpl implem
     return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellTtype.class));
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public ItemPresentation getPresentation() {
-    return HaskellPsiImplUtil.getPresentation(this);
-  }
+    @Override
+    public ItemPresentation getPresentation() {
+        return HaskellPsiImplUtil.getPresentation(this);
+    }
 
-  public Seq<HaskellNamedElement> getIdentifierElements() {
-    return HaskellPsiImplUtil.getIdentifierElements(this);
-  }
+    @Override
+    public Seq<HaskellNamedElement> getIdentifierElements() {
+        return HaskellPsiImplUtil.getIdentifierElements(this);
+    }
 
-  public Option<String> getModuleName() {
-    return HaskellPsiImplUtil.getModuleName(this);
-  }
+    @Override
+    public Option<String> getModuleName() {
+        return HaskellPsiImplUtil.getModuleName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVarConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVarConImpl.java
@@ -47,14 +47,14 @@ public class HaskellVarConImpl extends HaskellCompositeElementImpl implements Ha
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
-    @Override
-    public HaskellNamedElement getIdentifierElement() {
-        return HaskellPsiImplUtil.getIdentifierElement(this);
-    }
+  @Override
+  public HaskellNamedElement getIdentifierElement() {
+    return HaskellPsiImplUtil.getIdentifierElement(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVarConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVarConImpl.java
@@ -1,14 +1,12 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellVarConImpl extends HaskellCompositeElementImpl implements HaskellVarCon {
 
@@ -49,12 +47,14 @@ public class HaskellVarConImpl extends HaskellCompositeElementImpl implements Ha
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
-  public HaskellNamedElement getIdentifierElement() {
-    return HaskellPsiImplUtil.getIdentifierElement(this);
-  }
+    @Override
+    public HaskellNamedElement getIdentifierElement() {
+        return HaskellPsiImplUtil.getIdentifierElement(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVarImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVarImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellVar;
+import intellij.haskell.psi.HaskellVarid;
+import intellij.haskell.psi.HaskellVarsym;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellVarImpl extends HaskellCNameElementImpl implements HaskellVar {
 
@@ -37,8 +38,9 @@ public class HaskellVarImpl extends HaskellCNameElementImpl implements HaskellVa
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVarImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVarImpl.java
@@ -38,9 +38,9 @@ public class HaskellVarImpl extends HaskellCNameElementImpl implements HaskellVa
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVaridImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVaridImpl.java
@@ -32,22 +32,27 @@ public class HaskellVaridImpl extends HaskellNamedStubBasedPsiElementBase<Haskel
         else super.accept(visitor);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellVaridImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVaridImpl.java
@@ -57,4 +57,9 @@ public class HaskellVaridImpl extends HaskellNamedStubBasedPsiElementBase<Haskel
         return HaskellPsiImplUtil.getPresentation(this);
     }
 
+    @Override
+    public String toString() {
+        return HaskellPsiImplUtil.toString(this);
+    }
+
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVaropImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVaropImpl.java
@@ -38,9 +38,9 @@ public class HaskellVaropImpl extends HaskellCNameElementImpl implements Haskell
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-    @Override
-    public String getName() {
-        return HaskellPsiImplUtil.getName(this);
-    }
+  @Override
+  public String getName() {
+    return HaskellPsiImplUtil.getName(this);
+  }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVaropImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVaropImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellVarid;
+import intellij.haskell.psi.HaskellVarop;
+import intellij.haskell.psi.HaskellVarsym;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellVaropImpl extends HaskellCNameElementImpl implements HaskellVarop {
 
@@ -37,8 +38,9 @@ public class HaskellVaropImpl extends HaskellCNameElementImpl implements Haskell
     return PsiTreeUtil.getChildOfType(this, HaskellVarsym.class);
   }
 
-  public String getName() {
-    return HaskellPsiImplUtil.getName(this);
-  }
+    @Override
+    public String getName() {
+        return HaskellPsiImplUtil.getName(this);
+    }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellVarsymImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVarsymImpl.java
@@ -32,22 +32,27 @@ public class HaskellVarsymImpl extends HaskellNamedStubBasedPsiElementBase<Haske
         else super.accept(visitor);
     }
 
+    @Override
     public String getName() {
         return HaskellPsiImplUtil.getName(this);
     }
 
+    @Override
     public PsiElement setName(String newName) {
         return HaskellPsiImplUtil.setName(this, newName);
     }
 
+    @Override
     public HaskellNamedElement getNameIdentifier() {
         return HaskellPsiImplUtil.getNameIdentifier(this);
     }
 
+    @Override
     public PsiReference getReference() {
         return HaskellPsiImplUtil.getReference(this);
     }
 
+    @Override
     public ItemPresentation getPresentation() {
         return HaskellPsiImplUtil.getPresentation(this);
     }

--- a/gen/intellij/haskell/psi/impl/HaskellWhereClauseImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellWhereClauseImpl.java
@@ -1,0 +1,40 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static intellij.haskell.psi.HaskellTypes.*;
+import intellij.haskell.psi.*;
+
+public class HaskellWhereClauseImpl extends HaskellCompositeElementImpl implements HaskellWhereClause {
+
+  public HaskellWhereClauseImpl(ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull HaskellVisitor visitor) {
+    visitor.visitWhereClause(this);
+  }
+
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @Nullable
+  public HaskellTopDeclaration getTopDeclaration() {
+    return PsiTreeUtil.getChildOfType(this, HaskellTopDeclaration.class);
+  }
+
+  @Override
+  @NotNull
+  public List<HaskellTopDeclarationLine> getTopDeclarationLineList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellTopDeclarationLine.class);
+  }
+
+}

--- a/gen/intellij/haskell/psi/impl/HaskellWhereClauseImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellWhereClauseImpl.java
@@ -1,14 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class HaskellWhereClauseImpl extends HaskellCompositeElementImpl implements HaskellWhereClause {
 
@@ -23,6 +23,12 @@ public class HaskellWhereClauseImpl extends HaskellCompositeElementImpl implemen
   public void accept(@NotNull PsiElementVisitor visitor) {
     if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
     else super.accept(visitor);
+  }
+
+  @Override
+  @Nullable
+  public HaskellImportDeclarations getImportDeclarations() {
+    return PsiTreeUtil.getChildOfType(this, HaskellImportDeclarations.class);
   }
 
   @Override

--- a/src/main/scala/intellij/haskell/HaskellParserDefinition.scala
+++ b/src/main/scala/intellij/haskell/HaskellParserDefinition.scala
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull
 
 //noinspection TypeAnnotation
 object HaskellParserDefinition {
-  final val WhiteSpaces = TokenSet.create(TokenType.WHITE_SPACE)
+  final val WhiteSpaces = TokenSet.create(TokenType.WHITE_SPACE, HS_NEWLINE)
   final val Comments = TokenSet.create(HS_COMMENT, HS_NCOMMENT, HS_HADDOCK, HS_NHADDOCK)
   final val PragmaStartEndIds = TokenSet.create(HS_PRAGMA_START, HS_PRAGMA_END)
   final val ReservedIdS = TokenSet.create(HS_CASE, HS_CLASS, HS_DATA, HS_DEFAULT, HS_DERIVING, HS_DO, HS_ELSE, HS_IF, HS_IMPORT,

--- a/src/main/scala/intellij/haskell/haskell.bnf
+++ b/src/main/scala/intellij/haskell/haskell.bnf
@@ -61,9 +61,9 @@ file_header                 ::= (pragma onl)*
 pragma                      ::= PRAGMA_START general_pragma_content* PRAGMA_END {pin=1}
 general_pragma_content      ::= ONE_PRAGMA | PRAGMA_SEP | CHARACTER_LITERAL | STRING_LITERAL | NEWLINE | DASH | HASH
 
-module_body                 ::= module_declaration onl body | onl body
+module_body                 ::= module_declaration
 module_declaration          ::= MODULE modid onl pragma? onl (exports onl)? where_clause
-where_clause                ::= WHERE LEFT_BRACE top_declarations RIGHT_BRACE? {pin=1}
+where_clause                ::= WHERE LEFT_BRACE body RIGHT_BRACE? {pin=1}
 
 private body                ::= import_declarations top_declarations  (NEWLINE | DIRECTIVE)*
 import_declarations         ::= ((import_declaration | pragma | DIRECTIVE) onl)*
@@ -255,9 +255,9 @@ private general_id          ::= QUASIQUOTE | q_name | symbol_reserved_op | reser
                                   SEMICOLON | LEFT_BRACKET | RIGHT_BRACKET | literal | LEFT_BRACE | RIGHT_BRACE |
                                   COMMA | QUOTE | BACKQUOTE | fixity |
                                   pragma | DIRECTIVE | DOUBLE_QUOTES
-let_abstraction             ::= LET LEFT_BRACE let_definitions* RIGHT_BRACE? IN expression
+let_abstraction             ::= LET LEFT_BRACE let_definitions* RIGHT_BRACE? IN expression {pin=1}
 
-private let_definitions     ::= expression SEMICOLON
+private let_definitions     ::= expression SEMICOLON?
 
 dot_dot                     ::= DOT DOT
 private symbol_reserved_op  ::= dot_dot | COLON_COLON | EQUAL | BACKSLASH | VERTICAL_BAR | LEFT_ARROW | RIGHT_ARROW | AT | TILDE | DOUBLE_RIGHT_ARROW

--- a/src/main/scala/intellij/haskell/haskell.bnf
+++ b/src/main/scala/intellij/haskell/haskell.bnf
@@ -20,6 +20,7 @@
   elementTypePrefix="HS_"
 
   methods("varid|varsym|conid|consym|modid")=[getName setName getNameIdentifier getReference getPresentation]
+  methods("varid|conid|modid")=[toString]
   extends("varid|varsym|conid|consym|modid")="intellij.haskell.psi.impl.HaskellNamedStubBasedPsiElementBase<?>"
   implements("varid|varsym|conid|consym|modid")="intellij.haskell.psi.HaskellNamedElement"
   elementTypeFactory("varid|varsym|conid|consym|modid")="intellij.haskell.psi.impl.HaskellElementTypeFactory.factory"

--- a/src/main/scala/intellij/haskell/haskell.bnf
+++ b/src/main/scala/intellij/haskell/haskell.bnf
@@ -61,11 +61,12 @@ pragma                      ::= PRAGMA_START general_pragma_content* PRAGMA_END 
 general_pragma_content      ::= ONE_PRAGMA | PRAGMA_SEP | CHARACTER_LITERAL | STRING_LITERAL | NEWLINE | DASH | HASH
 
 module_body                 ::= module_declaration onl body | onl body
-module_declaration          ::= MODULE modid onl pragma? onl (exports onl)? WHERE
+module_declaration          ::= MODULE modid onl pragma? onl (exports onl)? where_clause
+where_clause                ::= WHERE LEFT_BRACE top_declarations RIGHT_BRACE? {pin=1}
 
 private body                ::= import_declarations top_declarations  (NEWLINE | DIRECTIVE)*
 import_declarations         ::= ((import_declaration | pragma | DIRECTIVE) onl)*
-private top_declarations    ::= (top_declaration_line (NEWLINE | DIRECTIVE)*)* top_declaration?
+private top_declarations    ::= (top_declaration_line (SEMICOLON | DIRECTIVE)*)* top_declaration?
 
 import_declaration          ::= IMPORT (onls pragma)? (onls import_qualified)? (onls import_package_name)? onls modid onls import_qualified_as? onls import_spec?    {methods=[getModuleName] pin=1}
 import_qualified            ::= "qualified"
@@ -81,7 +82,7 @@ import_hiding               ::= "hiding"
 import_id                   ::= TYPE? (cname LEFT_PAREN onls (cname_dot_dot onls (COMMA onls cname_dot_dot onls)* onls)? RIGHT_PAREN | cname)
 import_package_name         ::= text_literal
 
-top_declaration_line        ::= top_declaration SEMICOLON? NEWLINE
+top_declaration_line        ::= top_declaration SEMICOLON? NEWLINE?
 top_declaration             ::= type_declaration | data_declaration | newtype_declaration | class_declaration | instance_declaration | default_declaration |
                                   foreign_declaration | type_family_declaration | deriving_declaration | type_instance_declaration | type_signature |
                                   pragma | fixity_declaration | expression | DIRECTIVE
@@ -247,14 +248,17 @@ private cidecl              ::= pragma | instance_declaration | default_declarat
                                   newtype_declaration | data_declaration | type_declaration | type_family_declaration | line_expression
 
 expression                  ::= line_expression (nls line_expression)*
-private line_expression     ::= general_id+
+private line_expression     ::= (general_id | let_abstraction)+
 
 private general_id          ::= QUASIQUOTE | q_name | symbol_reserved_op | reserved_id | LEFT_PAREN | RIGHT_PAREN | FLOAT |
                                   SEMICOLON | LEFT_BRACKET | RIGHT_BRACKET | literal | LEFT_BRACE | RIGHT_BRACE |
                                   COMMA | QUOTE | BACKQUOTE | fixity |
                                   pragma | DIRECTIVE | DOUBLE_QUOTES
+let_abstraction             ::= LET LEFT_BRACE let_definitions* RIGHT_BRACE? IN expression
+
+private let_definitions     ::= expression SEMICOLON
 
 dot_dot                     ::= DOT DOT
 private symbol_reserved_op  ::= dot_dot | COLON_COLON | EQUAL | BACKSLASH | VERTICAL_BAR | LEFT_ARROW | RIGHT_ARROW | AT | TILDE | DOUBLE_RIGHT_ARROW
 
-reserved_id                 ::= CASE | CLASS | DATA | DEFAULT | DERIVING | DO | ELSE | IF | IMPORT | IN | INSTANCE | LET | MODULE | NEWTYPE | OF | THEN | TYPE | WHERE | UNDERSCORE
+reserved_id                 ::= CASE | CLASS | DATA | DEFAULT | DERIVING | DO | ELSE | IF | IMPORT | INSTANCE | MODULE | NEWTYPE | OF | THEN | TYPE | WHERE | UNDERSCORE

--- a/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
+++ b/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
@@ -47,6 +47,7 @@ class HaskellLayoutLexer(private val lexer: Lexer,
   private def currentToken = tokens.lift(currentTokenIndex)
 
   def start(buffer: CharSequence, startOffset: Int, endOffset: Int, initialState: Int) {
+    if (tokens.nonEmpty) return
     require(startOffset == 0, "does not support incremental lexing: startOffset must be 0")
     require(initialState == 0, "does not support incremental lexing: initialState must be 0")
 
@@ -129,12 +130,13 @@ class HaskellLayoutLexer(private val lexer: Lexer,
     val indentStack = new IndentStack()
     indentStack.push(-1) // top-level is an implicit section
 
-    for (token <- tokens) {
+    while (i < tokens.size) {
+      val token = tokens(i)
 
       state match {
         case WaitingForLayout =>
           if (token.isCode && token.column > indentStack.peek()) {
-            tokens.insert(i, virtualToken(layoutStart, tokens(if (i <= 0) 0 else i - 1)))
+            tokens.insert(i, virtualToken(layoutStart, tokens(i)))
             i += 1
             indentStack.push(token.column)
             if (!token.elementType.exists(layoutCreatingTokens.contains)) {

--- a/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
+++ b/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
@@ -79,6 +79,7 @@ class HaskellLayoutLexer(private val lexer: Lexer,
     var currentColumn = 0
 
     @tailrec
+    @inline
     def doIt(line: Line): Unit = {
       val token = Token(Option(lexer.getTokenType), lexer.getTokenStart, lexer.getTokenEnd, currentColumn, line)
       tokens += token
@@ -90,13 +91,16 @@ class HaskellLayoutLexer(private val lexer: Lexer,
       currentColumn += token.end - token.start
 
       if (!token.isEOF) {
-        if (token.elementType.contains(endOfLine)) {
+        val nextLine = if (token.elementType.contains(endOfLine)) {
           currentColumn = 0
+          Line()
+        } else {
+          line
         }
 
         lexer.advance()
 
-        doIt(Line())
+        doIt(nextLine)
       }
     }
 

--- a/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
+++ b/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
@@ -116,28 +116,18 @@ class HaskellLayoutLexer(private val lexer: Lexer,
     */
   private case object Normal extends State
 
-  /**
-    * The real initial state. We don't work on layout until we've encountered the first one.
-    */
-  private case object NotYetStarted extends State
-
-
   private def doLayout() {
     slurpTokens()
 
     // initial state
     var i = 0
-    var state: State = NotYetStarted
+    var state: State = Normal
     val indentStack = new IndentStack()
     indentStack.push(-1) // top-level is an implicit section
 
     for (token <- tokens) {
 
       state match {
-        case NotYetStarted =>
-          if (token.elementType.exists(layoutCreatingTokens.contains)) {
-            state = WaitingForLayout
-          }
         case WaitingForLayout =>
           if (token.isCode && token.column > indentStack.peek()) {
             tokens.insert(i, virtualToken(layoutStart, tokens(if (i <= 0) 0 else i - 1)))

--- a/src/main/scala/intellij/haskell/psi/impl/HaskellPsiImplUtil.scala
+++ b/src/main/scala/intellij/haskell/psi/impl/HaskellPsiImplUtil.scala
@@ -37,6 +37,18 @@ object HaskellPsiImplUtil {
     qVarCon.getText
   }
 
+  def toString(varid: HaskellVarid): String = {
+    s"HaskellVarid(${varid.getElementType})"
+  }
+
+  def toString(varid: HaskellConid): String = {
+    s"HaskellVarid(${varid.getElementType})"
+  }
+
+  def toString(varid: HaskellModid): String = {
+    s"HaskellVarid(${varid.getElementType})"
+  }
+
   def getIdentifierElement(qVarCon: HaskellQVarCon): HaskellNamedElement = {
     Option(qVarCon.getVarid).orElse(Option(qVarCon.getQCon).map(_.getConid)).orElse(Option(qVarCon.getConsym)).orElse(Option(qVarCon.getVarsym)).
       getOrElse(throw new IllegalStateException(s"Identifier for ${qVarCon.getText} should exist"))

--- a/src/test/scala/intellij/haskell/HaskellParsingTest.scala
+++ b/src/test/scala/intellij/haskell/HaskellParsingTest.scala
@@ -6,10 +6,14 @@ class HaskellParsingTest extends ParsingTestCase("", "hs", new HaskellParserDefi
   override def getTestDataPath: String = "src/test/testData/parsing-hs"
 
   def testPragma(): Unit = {
-    doTest(true)
+    doTest(true, true)
   }
 
   def testComplicatedPragma(): Unit = {
-    doTest(true)
+    doTest(true, true)
+  }
+
+  def testSimpleLayout(): Unit = {
+    doTest(true, true)
   }
 }

--- a/src/test/testData/parsing-hs/SimpleLayout.hs
+++ b/src/test/testData/parsing-hs/SimpleLayout.hs
@@ -1,0 +1,7 @@
+module TestModule where
+
+ these :: declarations are
+ insideOfALayout = let
+   test = bla
+   reTest = blllaaa
+ in test reTest

--- a/src/test/testData/parsing-hs/SimpleLayout.txt
+++ b/src/test/testData/parsing-hs/SimpleLayout.txt
@@ -1,0 +1,94 @@
+Haskell file
+  HS_FILE_HEADER
+    <empty list>
+  HS_MODULE_BODY
+    HS_MODULE_DECLARATION
+      PsiElement(HaskellTokenType.MODULE)('module')
+      PsiWhiteSpace(' ')
+      HaskellVarid(HS_MODID)
+        HaskellVarid(HS_CONID)
+          PsiElement(HaskellTokenType.CON_ID)('TestModule')
+      PsiWhiteSpace(' ')
+      HS_WHERE_CLAUSE
+        PsiElement(HaskellTokenType.WHERE)('where')
+        PsiWhiteSpace('\n')
+        PsiWhiteSpace('\n')
+        PsiWhiteSpace(' ')
+        HS_IMPORT_DECLARATIONS
+          <empty list>
+        HS_TOP_DECLARATION_LINE
+          HS_TOP_DECLARATION
+            HS_TYPE_SIGNATURE
+              HS_Q_NAMES
+                HS_Q_NAME
+                  HS_VAR_CON
+                    HaskellVarid(HS_VARID)
+                      PsiElement(HaskellTokenType.VAR_ID)('these')
+              PsiWhiteSpace(' ')
+              PsiElement(HaskellTokenType.COLON_COLON)('::')
+              PsiWhiteSpace(' ')
+              HS_TTYPE
+                HS_Q_NAME
+                  HS_VAR_CON
+                    HaskellVarid(HS_VARID)
+                      PsiElement(HaskellTokenType.VAR_ID)('declarations')
+                PsiWhiteSpace(' ')
+                HS_Q_NAME
+                  HS_VAR_CON
+                    HaskellVarid(HS_VARID)
+                      PsiElement(HaskellTokenType.VAR_ID)('are')
+        PsiWhiteSpace('\n')
+        PsiWhiteSpace(' ')
+        HS_TOP_DECLARATION_LINE
+          HS_TOP_DECLARATION
+            HS_EXPRESSION
+              HS_Q_NAME
+                HS_VAR_CON
+                  HaskellVarid(HS_VARID)
+                    PsiElement(HaskellTokenType.VAR_ID)('insideOfALayout')
+              PsiWhiteSpace(' ')
+              PsiElement(HaskellTokenType.EQUAL)('=')
+              PsiWhiteSpace(' ')
+              HS_LET_ABSTRACTION
+                PsiElement(HaskellTokenType.LET)('let')
+                PsiWhiteSpace('\n')
+                PsiWhiteSpace('   ')
+                HS_EXPRESSION
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('test')
+                  PsiWhiteSpace(' ')
+                  PsiElement(HaskellTokenType.EQUAL)('=')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('bla')
+                  PsiWhiteSpace('\n')
+                  PsiWhiteSpace('   ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('reTest')
+                  PsiWhiteSpace(' ')
+                  PsiElement(HaskellTokenType.EQUAL)('=')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('blllaaa')
+                PsiWhiteSpace('\n')
+                PsiWhiteSpace(' ')
+                PsiElement(HaskellTokenType.IN)('in')
+                PsiWhiteSpace(' ')
+                HS_EXPRESSION
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('test')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('reTest')


### PR DESCRIPTION
I have a `SimpleLayout.hs`, which uses a `let` expression (who has got a layout inside of it), whose AST is also included in the PR (as test data). You can easily see the syntax tree -- it's awesome.
Also, to enable AST-dumping-based testing, I've implemented `toString` for some AST nodes so the printed AST does not change.

This is a ground PR for a large refactoring of the syntax definition. Any questions are welcomed, both here and on the gitter channel.
