### PR TITLE
Address comments, support `do` notation

### DIFF
--- a/gen/intellij/haskell/psi/HaskellCcontext.java
+++ b/gen/intellij/haskell/psi/HaskellCcontext.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellCcontext extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellCdecls.java
+++ b/gen/intellij/haskell/psi/HaskellCdecls.java
@@ -16,7 +16,10 @@ public interface HaskellCdecls extends HaskellCompositeElement {
     @NotNull
     List<HaskellDefaultDeclaration> getDefaultDeclarationList();
 
-    @NotNull
+  @NotNull
+  List<HaskellDoNotation> getDoNotationList();
+
+  @NotNull
     List<HaskellDotDot> getDotDotList();
 
     @NotNull

--- a/gen/intellij/haskell/psi/HaskellCidecls.java
+++ b/gen/intellij/haskell/psi/HaskellCidecls.java
@@ -13,7 +13,10 @@ public interface HaskellCidecls extends HaskellCompositeElement {
     @NotNull
     List<HaskellDefaultDeclaration> getDefaultDeclarationList();
 
-    @NotNull
+  @NotNull
+  List<HaskellDoNotation> getDoNotationList();
+
+  @NotNull
     List<HaskellDotDot> getDotDotList();
 
     @NotNull

--- a/gen/intellij/haskell/psi/HaskellComments.java
+++ b/gen/intellij/haskell/psi/HaskellComments.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
-
 public interface HaskellComments extends HaskellCompositeElement {
 
 }

--- a/gen/intellij/haskell/psi/HaskellCon.java
+++ b/gen/intellij/haskell/psi/HaskellCon.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellCon extends HaskellCNameElement {
 

--- a/gen/intellij/haskell/psi/HaskellConop.java
+++ b/gen/intellij/haskell/psi/HaskellConop.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellConop extends HaskellCNameElement {
 

--- a/gen/intellij/haskell/psi/HaskellDataDeclarationDeriving.java
+++ b/gen/intellij/haskell/psi/HaskellDataDeclarationDeriving.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellDataDeclarationDeriving extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellDefaultDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellDefaultDeclaration.java
@@ -1,12 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
+
+import java.util.List;
 
 public interface HaskellDefaultDeclaration extends HaskellDeclarationElement {
 

--- a/gen/intellij/haskell/psi/HaskellDerivingDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellDerivingDeclaration.java
@@ -1,10 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
 

--- a/gen/intellij/haskell/psi/HaskellDoNotation.java
+++ b/gen/intellij/haskell/psi/HaskellDoNotation.java
@@ -1,0 +1,16 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface HaskellDoNotation extends HaskellCompositeElement {
+
+    @NotNull
+    List<HaskellExpression> getExpressionList();
+
+    @NotNull
+    List<HaskellLetLayout> getLetLayoutList();
+
+}

--- a/gen/intellij/haskell/psi/HaskellExports.java
+++ b/gen/intellij/haskell/psi/HaskellExports.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellExports extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellExpression.java
+++ b/gen/intellij/haskell/psi/HaskellExpression.java
@@ -7,7 +7,10 @@ import java.util.List;
 
 public interface HaskellExpression extends HaskellExpressionElement {
 
-    @NotNull
+  @NotNull
+  List<HaskellDoNotation> getDoNotationList();
+
+  @NotNull
     List<HaskellDotDot> getDotDotList();
 
     @NotNull

--- a/gen/intellij/haskell/psi/HaskellFixityDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellFixityDeclaration.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
 
 public interface HaskellFixityDeclaration extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellForeignDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellForeignDeclaration.java
@@ -1,10 +1,8 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
 import scala.Option;
 import scala.collection.Seq;
 

--- a/gen/intellij/haskell/psi/HaskellGtycon.java
+++ b/gen/intellij/haskell/psi/HaskellGtycon.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellGtycon extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellImportEmptySpec.java
+++ b/gen/intellij/haskell/psi/HaskellImportEmptySpec.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
-
 public interface HaskellImportEmptySpec extends HaskellCompositeElement {
 
 }

--- a/gen/intellij/haskell/psi/HaskellImportHiding.java
+++ b/gen/intellij/haskell/psi/HaskellImportHiding.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
-
 public interface HaskellImportHiding extends HaskellCompositeElement {
 
 }

--- a/gen/intellij/haskell/psi/HaskellImportHidingSpec.java
+++ b/gen/intellij/haskell/psi/HaskellImportHidingSpec.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellImportHidingSpec extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellImportIdsSpec.java
+++ b/gen/intellij/haskell/psi/HaskellImportIdsSpec.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellImportIdsSpec extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellImportQualified.java
+++ b/gen/intellij/haskell/psi/HaskellImportQualified.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
-
 public interface HaskellImportQualified extends HaskellCompositeElement {
 
 }

--- a/gen/intellij/haskell/psi/HaskellImportQualifiedAs.java
+++ b/gen/intellij/haskell/psi/HaskellImportQualifiedAs.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
 
 public interface HaskellImportQualifiedAs extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellImportSpec.java
+++ b/gen/intellij/haskell/psi/HaskellImportSpec.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellImportSpec extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellKindSignature.java
+++ b/gen/intellij/haskell/psi/HaskellKindSignature.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
 
 public interface HaskellKindSignature extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellLetAbstraction.java
+++ b/gen/intellij/haskell/psi/HaskellLetAbstraction.java
@@ -1,13 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellLetAbstraction extends HaskellCompositeElement {
 
+  @Nullable
+  HaskellExpression getExpression();
+
   @NotNull
-  List<HaskellExpression> getExpressionList();
+  HaskellLetLayout getLetLayout();
 
 }

--- a/gen/intellij/haskell/psi/HaskellLetLayout.java
+++ b/gen/intellij/haskell/psi/HaskellLetLayout.java
@@ -1,0 +1,13 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface HaskellLetLayout extends HaskellCompositeElement {
+
+    @NotNull
+    List<HaskellExpression> getExpressionList();
+
+}

--- a/gen/intellij/haskell/psi/HaskellListType.java
+++ b/gen/intellij/haskell/psi/HaskellListType.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellListType extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellQCon.java
+++ b/gen/intellij/haskell/psi/HaskellQCon.java
@@ -1,9 +1,8 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellQCon extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellQConQualifier.java
+++ b/gen/intellij/haskell/psi/HaskellQConQualifier.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellQConQualifier extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellQNames.java
+++ b/gen/intellij/haskell/psi/HaskellQNames.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellQNames extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellQVarCon.java
+++ b/gen/intellij/haskell/psi/HaskellQVarCon.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellQVarCon extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellReservedId.java
+++ b/gen/intellij/haskell/psi/HaskellReservedId.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
-
 public interface HaskellReservedId extends HaskellCompositeElement {
 
 }

--- a/gen/intellij/haskell/psi/HaskellScontext.java
+++ b/gen/intellij/haskell/psi/HaskellScontext.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellScontext extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellSimpleclass.java
+++ b/gen/intellij/haskell/psi/HaskellSimpleclass.java
@@ -1,9 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellSimpleclass extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellTypeDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellTypeDeclaration.java
@@ -1,12 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
+
+import java.util.List;
 
 public interface HaskellTypeDeclaration extends HaskellDeclarationElement {
 

--- a/gen/intellij/haskell/psi/HaskellTypeFamilyDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellTypeFamilyDeclaration.java
@@ -1,10 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.Seq;
 

--- a/gen/intellij/haskell/psi/HaskellTypeFamilyType.java
+++ b/gen/intellij/haskell/psi/HaskellTypeFamilyType.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 
 public interface HaskellTypeFamilyType extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellTypeInstanceDeclaration.java
+++ b/gen/intellij/haskell/psi/HaskellTypeInstanceDeclaration.java
@@ -1,10 +1,8 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
 import scala.Option;
 import scala.collection.Seq;
 

--- a/gen/intellij/haskell/psi/HaskellTypeSignature.java
+++ b/gen/intellij/haskell/psi/HaskellTypeSignature.java
@@ -1,12 +1,12 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
 import com.intellij.navigation.ItemPresentation;
+import org.jetbrains.annotations.NotNull;
 import scala.Option;
 import scala.collection.Seq;
+
+import java.util.List;
 
 public interface HaskellTypeSignature extends HaskellDeclarationElement {
 

--- a/gen/intellij/haskell/psi/HaskellTypes.java
+++ b/gen/intellij/haskell/psi/HaskellTypes.java
@@ -30,6 +30,7 @@ public interface HaskellTypes {
     IElementType HS_DEFAULT_DECLARATION = new HaskellCompositeElementType("HS_DEFAULT_DECLARATION");
     IElementType HS_DERIVING_DECLARATION = new HaskellCompositeElementType("HS_DERIVING_DECLARATION");
     IElementType HS_DOT_DOT = new HaskellCompositeElementType("HS_DOT_DOT");
+  IElementType HS_DO_NOTATION = new HaskellCompositeElementType("HS_DO_NOTATION");
     IElementType HS_EXPORT = new HaskellCompositeElementType("HS_EXPORT");
     IElementType HS_EXPORTS = new HaskellCompositeElementType("HS_EXPORTS");
     IElementType HS_EXPRESSION = new HaskellCompositeElementType("HS_EXPRESSION");
@@ -55,6 +56,7 @@ public interface HaskellTypes {
     IElementType HS_INSTVAR = new HaskellCompositeElementType("HS_INSTVAR");
     IElementType HS_KIND_SIGNATURE = new HaskellCompositeElementType("HS_KIND_SIGNATURE");
     IElementType HS_LET_ABSTRACTION = new HaskellCompositeElementType("HS_LET_ABSTRACTION");
+  IElementType HS_LET_LAYOUT = new HaskellCompositeElementType("HS_LET_LAYOUT");
     IElementType HS_LIST_TYPE = new HaskellCompositeElementType("HS_LIST_TYPE");
     IElementType HS_MODID = HaskellElementTypeFactory.factory("HS_MODID");
     IElementType HS_MODULE_BODY = new HaskellCompositeElementType("HS_MODULE_BODY");
@@ -216,139 +218,143 @@ public interface HaskellTypes {
             } else if (type == HS_DERIVING_DECLARATION) {
                 return new HaskellDerivingDeclarationImpl(node);
             } else if (type == HS_DOT_DOT) {
-                return new HaskellDotDotImpl(node);
+              return new HaskellDotDotImpl(node);
+            } else if (type == HS_DO_NOTATION) {
+              return new HaskellDoNotationImpl(node);
             } else if (type == HS_EXPORT) {
-                return new HaskellExportImpl(node);
+              return new HaskellExportImpl(node);
             } else if (type == HS_EXPORTS) {
-                return new HaskellExportsImpl(node);
+              return new HaskellExportsImpl(node);
             } else if (type == HS_EXPRESSION) {
-                return new HaskellExpressionImpl(node);
+              return new HaskellExpressionImpl(node);
             } else if (type == HS_FIELDDECL) {
-                return new HaskellFielddeclImpl(node);
+              return new HaskellFielddeclImpl(node);
             } else if (type == HS_FILE_HEADER) {
-                return new HaskellFileHeaderImpl(node);
+              return new HaskellFileHeaderImpl(node);
             } else if (type == HS_FIXITY_DECLARATION) {
-                return new HaskellFixityDeclarationImpl(node);
+              return new HaskellFixityDeclarationImpl(node);
             } else if (type == HS_FOREIGN_DECLARATION) {
-                return new HaskellForeignDeclarationImpl(node);
+              return new HaskellForeignDeclarationImpl(node);
             } else if (type == HS_GENERAL_PRAGMA_CONTENT) {
-                return new HaskellGeneralPragmaContentImpl(node);
+              return new HaskellGeneralPragmaContentImpl(node);
             } else if (type == HS_GTYCON) {
-                return new HaskellGtyconImpl(node);
+              return new HaskellGtyconImpl(node);
             } else if (type == HS_IMPORT_DECLARATION) {
-                return new HaskellImportDeclarationImpl(node);
+              return new HaskellImportDeclarationImpl(node);
             } else if (type == HS_IMPORT_DECLARATIONS) {
-                return new HaskellImportDeclarationsImpl(node);
+              return new HaskellImportDeclarationsImpl(node);
             } else if (type == HS_IMPORT_EMPTY_SPEC) {
-                return new HaskellImportEmptySpecImpl(node);
+              return new HaskellImportEmptySpecImpl(node);
             } else if (type == HS_IMPORT_HIDING) {
-                return new HaskellImportHidingImpl(node);
+              return new HaskellImportHidingImpl(node);
             } else if (type == HS_IMPORT_HIDING_SPEC) {
-                return new HaskellImportHidingSpecImpl(node);
+              return new HaskellImportHidingSpecImpl(node);
             } else if (type == HS_IMPORT_ID) {
-                return new HaskellImportIdImpl(node);
+              return new HaskellImportIdImpl(node);
             } else if (type == HS_IMPORT_IDS_SPEC) {
-                return new HaskellImportIdsSpecImpl(node);
+              return new HaskellImportIdsSpecImpl(node);
             } else if (type == HS_IMPORT_PACKAGE_NAME) {
-                return new HaskellImportPackageNameImpl(node);
+              return new HaskellImportPackageNameImpl(node);
             } else if (type == HS_IMPORT_QUALIFIED) {
-                return new HaskellImportQualifiedImpl(node);
+              return new HaskellImportQualifiedImpl(node);
             } else if (type == HS_IMPORT_QUALIFIED_AS) {
-                return new HaskellImportQualifiedAsImpl(node);
+              return new HaskellImportQualifiedAsImpl(node);
             } else if (type == HS_IMPORT_SPEC) {
-                return new HaskellImportSpecImpl(node);
+              return new HaskellImportSpecImpl(node);
             } else if (type == HS_INST) {
-                return new HaskellInstImpl(node);
+              return new HaskellInstImpl(node);
             } else if (type == HS_INSTANCE_DECLARATION) {
-                return new HaskellInstanceDeclarationImpl(node);
+              return new HaskellInstanceDeclarationImpl(node);
             } else if (type == HS_INSTVAR) {
-                return new HaskellInstvarImpl(node);
+              return new HaskellInstvarImpl(node);
             } else if (type == HS_KIND_SIGNATURE) {
-                return new HaskellKindSignatureImpl(node);
+              return new HaskellKindSignatureImpl(node);
             } else if (type == HS_LET_ABSTRACTION) {
-                return new HaskellLetAbstractionImpl(node);
+              return new HaskellLetAbstractionImpl(node);
+            } else if (type == HS_LET_LAYOUT) {
+              return new HaskellLetLayoutImpl(node);
             } else if (type == HS_LIST_TYPE) {
-                return new HaskellListTypeImpl(node);
+              return new HaskellListTypeImpl(node);
             } else if (type == HS_MODID) {
-                return new HaskellModidImpl(node);
+              return new HaskellModidImpl(node);
             } else if (type == HS_MODULE_BODY) {
-                return new HaskellModuleBodyImpl(node);
+              return new HaskellModuleBodyImpl(node);
             } else if (type == HS_MODULE_DECLARATION) {
-                return new HaskellModuleDeclarationImpl(node);
+              return new HaskellModuleDeclarationImpl(node);
             } else if (type == HS_NEWCONSTR) {
-                return new HaskellNewconstrImpl(node);
+              return new HaskellNewconstrImpl(node);
             } else if (type == HS_NEWCONSTR_FIELDDECL) {
-                return new HaskellNewconstrFielddeclImpl(node);
+              return new HaskellNewconstrFielddeclImpl(node);
             } else if (type == HS_NEWTYPE_DECLARATION) {
-                return new HaskellNewtypeDeclarationImpl(node);
+              return new HaskellNewtypeDeclarationImpl(node);
             } else if (type == HS_PRAGMA) {
-                return new HaskellPragmaImpl(node);
+              return new HaskellPragmaImpl(node);
             } else if (type == HS_QUALIFIER) {
-                return new HaskellQualifierImpl(node);
+              return new HaskellQualifierImpl(node);
             } else if (type == HS_Q_CON) {
-                return new HaskellQConImpl(node);
+              return new HaskellQConImpl(node);
             } else if (type == HS_Q_CON_QUALIFIER) {
-                return new HaskellQConQualifierImpl(node);
+              return new HaskellQConQualifierImpl(node);
             } else if (type == HS_Q_CON_QUALIFIER_1) {
-                return new HaskellQConQualifier1Impl(node);
+              return new HaskellQConQualifier1Impl(node);
             } else if (type == HS_Q_CON_QUALIFIER_2) {
-                return new HaskellQConQualifier2Impl(node);
+              return new HaskellQConQualifier2Impl(node);
             } else if (type == HS_Q_CON_QUALIFIER_3) {
-                return new HaskellQConQualifier3Impl(node);
+              return new HaskellQConQualifier3Impl(node);
             } else if (type == HS_Q_CON_QUALIFIER_4) {
-                return new HaskellQConQualifier4Impl(node);
+              return new HaskellQConQualifier4Impl(node);
             } else if (type == HS_Q_NAME) {
-                return new HaskellQNameImpl(node);
+              return new HaskellQNameImpl(node);
             } else if (type == HS_Q_NAMES) {
-                return new HaskellQNamesImpl(node);
+              return new HaskellQNamesImpl(node);
             } else if (type == HS_Q_VAR_CON) {
-                return new HaskellQVarConImpl(node);
+              return new HaskellQVarConImpl(node);
             } else if (type == HS_RESERVED_ID) {
-                return new HaskellReservedIdImpl(node);
+              return new HaskellReservedIdImpl(node);
             } else if (type == HS_SCONTEXT) {
-                return new HaskellScontextImpl(node);
+              return new HaskellScontextImpl(node);
             } else if (type == HS_SHEBANG_LINE) {
-                return new HaskellShebangLineImpl(node);
+              return new HaskellShebangLineImpl(node);
             } else if (type == HS_SIMPLECLASS) {
-                return new HaskellSimpleclassImpl(node);
+              return new HaskellSimpleclassImpl(node);
             } else if (type == HS_SIMPLETYPE) {
-                return new HaskellSimpletypeImpl(node);
+              return new HaskellSimpletypeImpl(node);
             } else if (type == HS_TEXT_LITERAL) {
-                return new HaskellTextLiteralImpl(node);
+              return new HaskellTextLiteralImpl(node);
             } else if (type == HS_TOP_DECLARATION) {
-                return new HaskellTopDeclarationImpl(node);
+              return new HaskellTopDeclarationImpl(node);
             } else if (type == HS_TOP_DECLARATION_LINE) {
-                return new HaskellTopDeclarationLineImpl(node);
+              return new HaskellTopDeclarationLineImpl(node);
             } else if (type == HS_TTYPE) {
-                return new HaskellTtypeImpl(node);
+              return new HaskellTtypeImpl(node);
             } else if (type == HS_TTYPE_1) {
-                return new HaskellTtype1Impl(node);
+              return new HaskellTtype1Impl(node);
             } else if (type == HS_TTYPE_2) {
-                return new HaskellTtype2Impl(node);
+              return new HaskellTtype2Impl(node);
             } else if (type == HS_TYPE_DECLARATION) {
-                return new HaskellTypeDeclarationImpl(node);
+              return new HaskellTypeDeclarationImpl(node);
             } else if (type == HS_TYPE_EQUALITY) {
-                return new HaskellTypeEqualityImpl(node);
+              return new HaskellTypeEqualityImpl(node);
             } else if (type == HS_TYPE_FAMILY_DECLARATION) {
-                return new HaskellTypeFamilyDeclarationImpl(node);
+              return new HaskellTypeFamilyDeclarationImpl(node);
             } else if (type == HS_TYPE_FAMILY_TYPE) {
-                return new HaskellTypeFamilyTypeImpl(node);
+              return new HaskellTypeFamilyTypeImpl(node);
             } else if (type == HS_TYPE_INSTANCE_DECLARATION) {
-                return new HaskellTypeInstanceDeclarationImpl(node);
+              return new HaskellTypeInstanceDeclarationImpl(node);
             } else if (type == HS_TYPE_SIGNATURE) {
-                return new HaskellTypeSignatureImpl(node);
+              return new HaskellTypeSignatureImpl(node);
             } else if (type == HS_VAR) {
-                return new HaskellVarImpl(node);
+              return new HaskellVarImpl(node);
             } else if (type == HS_VARID) {
-                return new HaskellVaridImpl(node);
+              return new HaskellVaridImpl(node);
             } else if (type == HS_VAROP) {
-                return new HaskellVaropImpl(node);
+              return new HaskellVaropImpl(node);
             } else if (type == HS_VARSYM) {
-                return new HaskellVarsymImpl(node);
+              return new HaskellVarsymImpl(node);
             } else if (type == HS_VAR_CON) {
-                return new HaskellVarConImpl(node);
+              return new HaskellVarConImpl(node);
             } else if (type == HS_WHERE_CLAUSE) {
-                return new HaskellWhereClauseImpl(node);
+              return new HaskellWhereClauseImpl(node);
             }
             throw new AssertionError("Unknown element type: " + type);
         }

--- a/gen/intellij/haskell/psi/HaskellVar.java
+++ b/gen/intellij/haskell/psi/HaskellVar.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellVar extends HaskellCNameElement {
 

--- a/gen/intellij/haskell/psi/HaskellVarCon.java
+++ b/gen/intellij/haskell/psi/HaskellVarCon.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellVarCon extends HaskellCompositeElement {
 

--- a/gen/intellij/haskell/psi/HaskellVarop.java
+++ b/gen/intellij/haskell/psi/HaskellVarop.java
@@ -1,9 +1,7 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.Nullable;
 
 public interface HaskellVarop extends HaskellCNameElement {
 

--- a/gen/intellij/haskell/psi/HaskellVisitor.java
+++ b/gen/intellij/haskell/psi/HaskellVisitor.java
@@ -91,7 +91,11 @@ public class HaskellVisitor extends PsiElementVisitor {
         visitDeclarationElement(o);
     }
 
-    public void visitDotDot(@NotNull HaskellDotDot o) {
+  public void visitDoNotation(@NotNull HaskellDoNotation o) {
+    visitCompositeElement(o);
+  }
+
+  public void visitDotDot(@NotNull HaskellDotDot o) {
         visitCompositeElement(o);
     }
 
@@ -194,6 +198,10 @@ public class HaskellVisitor extends PsiElementVisitor {
     public void visitLetAbstraction(@NotNull HaskellLetAbstraction o) {
         visitCompositeElement(o);
     }
+
+  public void visitLetLayout(@NotNull HaskellLetLayout o) {
+    visitCompositeElement(o);
+  }
 
     public void visitListType(@NotNull HaskellListType o) {
         visitCompositeElement(o);

--- a/gen/intellij/haskell/psi/HaskellWhereClause.java
+++ b/gen/intellij/haskell/psi/HaskellWhereClause.java
@@ -12,7 +12,7 @@ public interface HaskellWhereClause extends HaskellCompositeElement {
     HaskellImportDeclarations getImportDeclarations();
 
     @Nullable
-  HaskellTopDeclaration getTopDeclaration();
+    HaskellTopDeclaration getTopDeclaration();
 
   @NotNull
   List<HaskellTopDeclarationLine> getTopDeclarationLineList();

--- a/gen/intellij/haskell/psi/impl/HaskellCcontextImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellCcontextImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellCcontext;
+import intellij.haskell.psi.HaskellClazz;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellCcontextImpl extends HaskellCompositeElementImpl implements HaskellCcontext {
 
@@ -21,7 +22,7 @@ public class HaskellCcontextImpl extends HaskellCompositeElementImpl implements 
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellCdeclsImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellCdeclsImpl.java
@@ -42,7 +42,13 @@ public class HaskellCdeclsImpl extends HaskellCompositeElementImpl implements Ha
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDefaultDeclaration.class);
     }
 
-    @Override
+  @Override
+  @NotNull
+  public List<HaskellDoNotation> getDoNotationList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDoNotation.class);
+  }
+
+  @Override
     @NotNull
     public List<HaskellDotDot> getDotDotList() {
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDotDot.class);

--- a/gen/intellij/haskell/psi/impl/HaskellCideclsImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellCideclsImpl.java
@@ -36,7 +36,13 @@ public class HaskellCideclsImpl extends HaskellCompositeElementImpl implements H
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDefaultDeclaration.class);
     }
 
-    @Override
+  @Override
+  @NotNull
+  public List<HaskellDoNotation> getDoNotationList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDoNotation.class);
+  }
+
+  @Override
     @NotNull
     public List<HaskellDotDot> getDotDotList() {
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDotDot.class);

--- a/gen/intellij/haskell/psi/impl/HaskellCommentsImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellCommentsImpl.java
@@ -1,14 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellComments;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellCommentsImpl extends HaskellCompositeElementImpl implements HaskellComments {
 
@@ -21,7 +18,7 @@ public class HaskellCommentsImpl extends HaskellCompositeElementImpl implements 
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConImpl.java
@@ -22,7 +22,7 @@ public class HaskellConImpl extends HaskellCNameElementImpl implements HaskellCo
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellConopImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellConopImpl.java
@@ -22,7 +22,7 @@ public class HaskellConopImpl extends HaskellCNameElementImpl implements Haskell
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellDataDeclarationDerivingImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDataDeclarationDerivingImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellDataDeclarationDeriving;
+import intellij.haskell.psi.HaskellTtype;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellDataDeclarationDerivingImpl extends HaskellCompositeElementImpl implements HaskellDataDeclarationDeriving {
 
@@ -21,7 +22,7 @@ public class HaskellDataDeclarationDerivingImpl extends HaskellCompositeElementI
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellDefaultDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDefaultDeclarationImpl.java
@@ -24,7 +24,7 @@ public class HaskellDefaultDeclarationImpl extends HaskellCompositeElementImpl i
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellDerivingDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDerivingDeclarationImpl.java
@@ -22,7 +22,7 @@ public class HaskellDerivingDeclarationImpl extends HaskellCompositeElementImpl 
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellDoNotationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellDoNotationImpl.java
@@ -1,0 +1,42 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import intellij.haskell.psi.HaskellDoNotation;
+import intellij.haskell.psi.HaskellExpression;
+import intellij.haskell.psi.HaskellLetLayout;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class HaskellDoNotationImpl extends HaskellCompositeElementImpl implements HaskellDoNotation {
+
+    public HaskellDoNotationImpl(ASTNode node) {
+        super(node);
+    }
+
+    public void accept(@NotNull HaskellVisitor visitor) {
+        visitor.visitDoNotation(this);
+    }
+
+    public void accept(@NotNull PsiElementVisitor visitor) {
+        if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
+        else super.accept(visitor);
+    }
+
+    @Override
+    @NotNull
+    public List<HaskellExpression> getExpressionList() {
+        return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellExpression.class);
+    }
+
+    @Override
+    @NotNull
+    public List<HaskellLetLayout> getLetLayoutList() {
+        return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellLetLayout.class);
+    }
+
+}

--- a/gen/intellij/haskell/psi/impl/HaskellExportsImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellExportsImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellExport;
+import intellij.haskell.psi.HaskellExports;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellExportsImpl extends HaskellCompositeElementImpl implements HaskellExports {
 
@@ -21,7 +22,7 @@ public class HaskellExportsImpl extends HaskellCompositeElementImpl implements H
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellExpressionImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellExpressionImpl.java
@@ -24,7 +24,13 @@ public class HaskellExpressionImpl extends HaskellExpressionElementImpl implemen
         else super.accept(visitor);
     }
 
-    @Override
+  @Override
+  @NotNull
+  public List<HaskellDoNotation> getDoNotationList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDoNotation.class);
+  }
+
+  @Override
     @NotNull
     public List<HaskellDotDot> getDotDotList() {
         return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellDotDot.class);

--- a/gen/intellij/haskell/psi/impl/HaskellFixityDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellFixityDeclarationImpl.java
@@ -1,14 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellFixityDeclaration;
+import intellij.haskell.psi.HaskellQNames;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellFixityDeclarationImpl extends HaskellCompositeElementImpl implements HaskellFixityDeclaration {
 
@@ -21,7 +20,7 @@ public class HaskellFixityDeclarationImpl extends HaskellCompositeElementImpl im
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellForeignDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellForeignDeclarationImpl.java
@@ -24,7 +24,7 @@ public class HaskellForeignDeclarationImpl extends HaskellCompositeElementImpl i
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellGtyconImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellGtyconImpl.java
@@ -1,14 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellGtycon;
+import intellij.haskell.psi.HaskellQName;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellGtyconImpl extends HaskellCompositeElementImpl implements HaskellGtycon {
 
@@ -21,7 +21,7 @@ public class HaskellGtyconImpl extends HaskellCompositeElementImpl implements Ha
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellImportEmptySpecImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportEmptySpecImpl.java
@@ -1,14 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellImportEmptySpec;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellImportEmptySpecImpl extends HaskellCompositeElementImpl implements HaskellImportEmptySpec {
 
@@ -21,7 +18,7 @@ public class HaskellImportEmptySpecImpl extends HaskellCompositeElementImpl impl
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellImportHidingImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportHidingImpl.java
@@ -1,14 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellImportHiding;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellImportHidingImpl extends HaskellCompositeElementImpl implements HaskellImportHiding {
 
@@ -21,7 +18,7 @@ public class HaskellImportHidingImpl extends HaskellCompositeElementImpl impleme
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellImportHidingSpecImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportHidingSpecImpl.java
@@ -1,14 +1,16 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellImportHiding;
+import intellij.haskell.psi.HaskellImportHidingSpec;
+import intellij.haskell.psi.HaskellImportId;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellImportHidingSpecImpl extends HaskellCompositeElementImpl implements HaskellImportHidingSpec {
 
@@ -21,7 +23,7 @@ public class HaskellImportHidingSpecImpl extends HaskellCompositeElementImpl imp
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellImportIdsSpecImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportIdsSpecImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellImportId;
+import intellij.haskell.psi.HaskellImportIdsSpec;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellImportIdsSpecImpl extends HaskellCompositeElementImpl implements HaskellImportIdsSpec {
 
@@ -21,7 +22,7 @@ public class HaskellImportIdsSpecImpl extends HaskellCompositeElementImpl implem
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellImportQualifiedAsImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportQualifiedAsImpl.java
@@ -1,14 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellImportQualifiedAs;
+import intellij.haskell.psi.HaskellQualifier;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellImportQualifiedAsImpl extends HaskellCompositeElementImpl implements HaskellImportQualifiedAs {
 
@@ -21,7 +20,7 @@ public class HaskellImportQualifiedAsImpl extends HaskellCompositeElementImpl im
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellImportQualifiedImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportQualifiedImpl.java
@@ -1,14 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellImportQualified;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellImportQualifiedImpl extends HaskellCompositeElementImpl implements HaskellImportQualified {
 
@@ -21,7 +18,7 @@ public class HaskellImportQualifiedImpl extends HaskellCompositeElementImpl impl
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellImportSpecImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellImportSpecImpl.java
@@ -1,14 +1,12 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellImportSpecImpl extends HaskellCompositeElementImpl implements HaskellImportSpec {
 
@@ -21,7 +19,7 @@ public class HaskellImportSpecImpl extends HaskellCompositeElementImpl implement
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellKindSignatureImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellKindSignatureImpl.java
@@ -1,14 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellKindSignature;
+import intellij.haskell.psi.HaskellQName;
+import intellij.haskell.psi.HaskellTtype;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellKindSignatureImpl extends HaskellCompositeElementImpl implements HaskellKindSignature {
 
@@ -21,7 +21,7 @@ public class HaskellKindSignatureImpl extends HaskellCompositeElementImpl implem
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellLetAbstractionImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellLetAbstractionImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellExpression;
+import intellij.haskell.psi.HaskellLetAbstraction;
+import intellij.haskell.psi.HaskellLetLayout;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellLetAbstractionImpl extends HaskellCompositeElementImpl implements HaskellLetAbstraction {
 
@@ -21,14 +22,20 @@ public class HaskellLetAbstractionImpl extends HaskellCompositeElementImpl imple
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 
   @Override
+  @Nullable
+  public HaskellExpression getExpression() {
+    return PsiTreeUtil.getChildOfType(this, HaskellExpression.class);
+  }
+
+  @Override
   @NotNull
-  public List<HaskellExpression> getExpressionList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellExpression.class);
+  public HaskellLetLayout getLetLayout() {
+    return notNullChild(PsiTreeUtil.getChildOfType(this, HaskellLetLayout.class));
   }
 
 }

--- a/gen/intellij/haskell/psi/impl/HaskellLetLayoutImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellLetLayoutImpl.java
@@ -1,0 +1,35 @@
+// This is a generated file. Not intended for manual editing.
+package intellij.haskell.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import intellij.haskell.psi.HaskellExpression;
+import intellij.haskell.psi.HaskellLetLayout;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class HaskellLetLayoutImpl extends HaskellCompositeElementImpl implements HaskellLetLayout {
+
+    public HaskellLetLayoutImpl(ASTNode node) {
+        super(node);
+    }
+
+    public void accept(@NotNull HaskellVisitor visitor) {
+        visitor.visitLetLayout(this);
+    }
+
+    public void accept(@NotNull PsiElementVisitor visitor) {
+        if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
+        else super.accept(visitor);
+    }
+
+    @Override
+    @NotNull
+    public List<HaskellExpression> getExpressionList() {
+        return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellExpression.class);
+    }
+
+}

--- a/gen/intellij/haskell/psi/impl/HaskellListTypeImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellListTypeImpl.java
@@ -1,14 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellListType;
+import intellij.haskell.psi.HaskellQName;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellListTypeImpl extends HaskellCompositeElementImpl implements HaskellListType {
 
@@ -21,7 +21,7 @@ public class HaskellListTypeImpl extends HaskellCompositeElementImpl implements 
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellQConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQConImpl.java
@@ -1,14 +1,12 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellQConImpl extends HaskellCompositeElementImpl implements HaskellQCon {
 
@@ -21,7 +19,7 @@ public class HaskellQConImpl extends HaskellCompositeElementImpl implements Hask
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellQConQualifierImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQConQualifierImpl.java
@@ -1,14 +1,12 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaskellQConQualifierImpl extends HaskellCompositeElementImpl implements HaskellQConQualifier {
 
@@ -21,7 +19,7 @@ public class HaskellQConQualifierImpl extends HaskellCompositeElementImpl implem
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellQNamesImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQNamesImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellQName;
+import intellij.haskell.psi.HaskellQNames;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellQNamesImpl extends HaskellCompositeElementImpl implements HaskellQNames {
 
@@ -21,7 +22,7 @@ public class HaskellQNamesImpl extends HaskellCompositeElementImpl implements Ha
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellQVarConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellQVarConImpl.java
@@ -19,7 +19,7 @@ public class HaskellQVarConImpl extends HaskellCompositeElementImpl implements H
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellReservedIdImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellReservedIdImpl.java
@@ -1,14 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellReservedId;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
 
 public class HaskellReservedIdImpl extends HaskellCompositeElementImpl implements HaskellReservedId {
 
@@ -21,7 +18,7 @@ public class HaskellReservedIdImpl extends HaskellCompositeElementImpl implement
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellScontextImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellScontextImpl.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellScontext;
+import intellij.haskell.psi.HaskellSimpleclass;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellScontextImpl extends HaskellCompositeElementImpl implements HaskellScontext {
 
@@ -21,7 +22,7 @@ public class HaskellScontextImpl extends HaskellCompositeElementImpl implements 
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellSimpleclassImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellSimpleclassImpl.java
@@ -1,14 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
-import intellij.haskell.psi.*;
+import intellij.haskell.psi.HaskellQName;
+import intellij.haskell.psi.HaskellSimpleclass;
+import intellij.haskell.psi.HaskellTtype;
+import intellij.haskell.psi.HaskellVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class HaskellSimpleclassImpl extends HaskellCompositeElementImpl implements HaskellSimpleclass {
 
@@ -21,7 +24,7 @@ public class HaskellSimpleclassImpl extends HaskellCompositeElementImpl implemen
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellTypeDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeDeclarationImpl.java
@@ -24,7 +24,7 @@ public class HaskellTypeDeclarationImpl extends HaskellCompositeElementImpl impl
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellTypeFamilyDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeFamilyDeclarationImpl.java
@@ -22,7 +22,7 @@ public class HaskellTypeFamilyDeclarationImpl extends HaskellCompositeElementImp
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellTypeFamilyTypeImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeFamilyTypeImpl.java
@@ -1,14 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package intellij.haskell.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static intellij.haskell.psi.HaskellTypes.*;
 import intellij.haskell.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class HaskellTypeFamilyTypeImpl extends HaskellCompositeElementImpl implements HaskellTypeFamilyType {
 
@@ -21,7 +20,7 @@ public class HaskellTypeFamilyTypeImpl extends HaskellCompositeElementImpl imple
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellTypeInstanceDeclarationImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeInstanceDeclarationImpl.java
@@ -24,7 +24,7 @@ public class HaskellTypeInstanceDeclarationImpl extends HaskellCompositeElementI
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellTypeSignatureImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellTypeSignatureImpl.java
@@ -23,7 +23,7 @@ public class HaskellTypeSignatureImpl extends HaskellCompositeElementImpl implem
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellVarConImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVarConImpl.java
@@ -19,7 +19,7 @@ public class HaskellVarConImpl extends HaskellCompositeElementImpl implements Ha
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellVarImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVarImpl.java
@@ -22,7 +22,7 @@ public class HaskellVarImpl extends HaskellCNameElementImpl implements HaskellVa
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellVaropImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellVaropImpl.java
@@ -22,7 +22,7 @@ public class HaskellVaropImpl extends HaskellCNameElementImpl implements Haskell
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/gen/intellij/haskell/psi/impl/HaskellWhereClauseImpl.java
+++ b/gen/intellij/haskell/psi/impl/HaskellWhereClauseImpl.java
@@ -21,7 +21,7 @@ public class HaskellWhereClauseImpl extends HaskellCompositeElementImpl implemen
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor)visitor);
+    if (visitor instanceof HaskellVisitor) accept((HaskellVisitor) visitor);
     else super.accept(visitor);
   }
 

--- a/src/main/scala/intellij/haskell/HaskellParserDefinition.scala
+++ b/src/main/scala/intellij/haskell/HaskellParserDefinition.scala
@@ -60,7 +60,7 @@ class HaskellParserDefinition extends ParserDefinition {
       HaskellTypes.HS_SEMICOLON,
       HaskellTypes.HS_RIGHT_BRACE,
       TokenSet.orSet(Comments, WhiteSpaces, TokenSet.create(HS_LEFT_BRACE, HS_SEMICOLON, HS_RIGHT_BRACE)),
-      TokenSet.create(HS_WHERE, HS_LET),
+      TokenSet.create(HS_WHERE, HS_LET, HS_DO),
       LetIn(HS_LET, HS_IN)
     )
   }

--- a/src/main/scala/intellij/haskell/haskell.bnf
+++ b/src/main/scala/intellij/haskell/haskell.bnf
@@ -249,17 +249,20 @@ private cidecl              ::= pragma | instance_declaration | default_declarat
                                   newtype_declaration | data_declaration | type_declaration | type_family_declaration | line_expression
 
 expression                  ::= line_expression (nls line_expression)*
-private line_expression     ::= (general_id | let_abstraction)+
+private line_expression     ::= (general_id | let_abstraction | do_notation)+
 
 private general_id          ::= QUASIQUOTE | q_name | symbol_reserved_op | reserved_id | LEFT_PAREN | RIGHT_PAREN | FLOAT |
                                   SEMICOLON | LEFT_BRACKET | RIGHT_BRACKET | literal | LEFT_BRACE | RIGHT_BRACE |
                                   COMMA | QUOTE | BACKQUOTE | fixity |
                                   pragma | DIRECTIVE | DOUBLE_QUOTES
-let_abstraction             ::= LET LEFT_BRACE let_definitions* RIGHT_BRACE? IN expression {pin=1}
+let_abstraction             ::= let_layout IN expression {pin=1}
+let_layout                  ::= LET LEFT_BRACE let_definition* RIGHT_BRACE? {pin=1}
+do_notation                 ::= DO LEFT_BRACE do_clause* RIGHT_BRACE? {pin=1}
 
-private let_definitions     ::= expression SEMICOLON?
+private let_definition      ::= expression SEMICOLON?
+private do_clause           ::= (let_layout | expression) SEMICOLON?
 
 dot_dot                     ::= DOT DOT
 private symbol_reserved_op  ::= dot_dot | COLON_COLON | EQUAL | BACKSLASH | VERTICAL_BAR | LEFT_ARROW | RIGHT_ARROW | AT | TILDE | DOUBLE_RIGHT_ARROW
 
-reserved_id                 ::= CASE | CLASS | DATA | DEFAULT | DERIVING | DO | ELSE | IF | IMPORT | INSTANCE | MODULE | NEWTYPE | OF | THEN | TYPE | WHERE | UNDERSCORE
+reserved_id                 ::= CASE | CLASS | DATA | DEFAULT | DERIVING | ELSE | IF | IMPORT | INSTANCE | MODULE | NEWTYPE | OF | THEN | TYPE | WHERE | UNDERSCORE

--- a/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
+++ b/src/main/scala/intellij/haskell/psi/HaskellLayoutLexer.scala
@@ -36,7 +36,7 @@ class HaskellLayoutLexer(private val lexer: Lexer,
     override def toString = s"${elementType.toString} ($start, $end)"
 
     val isEOF: Boolean = elementType.isEmpty
-    def isCode: Boolean = elementType.exists(et => !nonCodeTokens.contains(et)) && !isEOF
+    val isCode: Boolean = elementType.exists(et => !nonCodeTokens.contains(et)) && !isEOF
 
     def isNextLayoutLine: Boolean = isCode && line.columnWhereCodeStarts.contains(column)
   }
@@ -47,7 +47,6 @@ class HaskellLayoutLexer(private val lexer: Lexer,
   private def currentToken = tokens.lift(currentTokenIndex)
 
   def start(buffer: CharSequence, startOffset: Int, endOffset: Int, initialState: Int) {
-    if (tokens.nonEmpty) return
     require(startOffset == 0, "does not support incremental lexing: startOffset must be 0")
     require(initialState == 0, "does not support incremental lexing: initialState must be 0")
 

--- a/src/test/scala/intellij/haskell/HaskellParsingTest.scala
+++ b/src/test/scala/intellij/haskell/HaskellParsingTest.scala
@@ -16,4 +16,8 @@ class HaskellParsingTest extends ParsingTestCase("", "hs", new HaskellParserDefi
   def testSimpleLayout(): Unit = {
     doTest(true, true)
   }
+
+  def testDoLayout(): Unit = {
+    doTest(true, true)
+  }
 }

--- a/src/test/testData/parsing-hs/DoLayout.hs
+++ b/src/test/testData/parsing-hs/DoLayout.hs
@@ -1,0 +1,6 @@
+module TestModule where
+
+ doNotation = do
+   e <- f
+   a <- g
+   return $ e + a

--- a/src/test/testData/parsing-hs/DoLayout.txt
+++ b/src/test/testData/parsing-hs/DoLayout.txt
@@ -1,0 +1,83 @@
+Haskell file
+  HS_FILE_HEADER
+    <empty list>
+  HS_MODULE_BODY
+    HS_MODULE_DECLARATION
+      PsiElement(HaskellTokenType.MODULE)('module')
+      PsiWhiteSpace(' ')
+      HaskellVarid(HS_MODID)
+        HaskellVarid(HS_CONID)
+          PsiElement(HaskellTokenType.CON_ID)('TestModule')
+      PsiWhiteSpace(' ')
+      HS_WHERE_CLAUSE
+        PsiElement(HaskellTokenType.WHERE)('where')
+        PsiWhiteSpace('\n')
+        PsiWhiteSpace('\n')
+        PsiWhiteSpace(' ')
+        HS_IMPORT_DECLARATIONS
+          <empty list>
+        HS_TOP_DECLARATION_LINE
+          HS_TOP_DECLARATION
+            HS_EXPRESSION
+              HS_Q_NAME
+                HS_VAR_CON
+                  HaskellVarid(HS_VARID)
+                    PsiElement(HaskellTokenType.VAR_ID)('doNotation')
+              PsiWhiteSpace(' ')
+              PsiElement(HaskellTokenType.EQUAL)('=')
+              PsiWhiteSpace(' ')
+              HS_DO_NOTATION
+                PsiElement(HaskellTokenType.DO)('do')
+                PsiWhiteSpace('\n')
+                PsiWhiteSpace('   ')
+                HS_EXPRESSION
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('e')
+                  PsiWhiteSpace(' ')
+                  PsiElement(HaskellTokenType.LEFT_ARROW)('<-')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('f')
+                  PsiWhiteSpace('\n')
+                  PsiWhiteSpace('   ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('a')
+                  PsiWhiteSpace(' ')
+                  PsiElement(HaskellTokenType.LEFT_ARROW)('<-')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('g')
+                  PsiWhiteSpace('\n')
+                  PsiWhiteSpace('   ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('return')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      intellij.haskell.psi.impl.HaskellVarsymImpl@771f3822
+                        PsiElement(HaskellTokenType.VARSYM_ID)('$')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('e')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      intellij.haskell.psi.impl.HaskellVarsymImpl@371c712d
+                        PsiElement(HaskellTokenType.VARSYM_ID)('+')
+                  PsiWhiteSpace(' ')
+                  HS_Q_NAME
+                    HS_VAR_CON
+                      HaskellVarid(HS_VARID)
+                        PsiElement(HaskellTokenType.VAR_ID)('a')


### PR DESCRIPTION
See the added test.

Note: I'm struggling with the generated code. I guessed you're running "code cleanup" before committing them, so did I. However, some of them are 2-spaces-indented, some are 4-spaces. I'm lost -- I regenerate the code and got most of them changed.
@rikvdkleij there should be a solution.