### PR TITLE
Have (+) show correct quick documentation (none). Fix issue #436.

### DIFF
--- a/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
@@ -102,7 +102,7 @@ object HoogleComponent {
 
     ProgressManager.checkCanceled()
 
-    runHoogle(project, Seq("-i", name, s"+$moduleName", "+Prelude")).
+    runHoogle(project, Seq("-i", name, s"+$moduleName", "+Prelude", "is:exact")).
       flatMap(processOutput =>
         if (processOutput.getStdoutLines.isEmpty || processOutput.getStdout.contains("No results found")) {
           None


### PR DESCRIPTION
Addressing #436 by adding is:exact to the arguments sent to the hoogle CLI to avoid showing the documentation for (++) when requesting the documentation for (+).

The popup now shows:
> ```
> No documentation found
> ```
> -----
> GHC.Num    -- No type info available
> 
> -----
![Quick documentation for (+) shows no documentation found as expected](https://user-images.githubusercontent.com/16341/59568301-71f3d000-9053-11e9-80a7-0658812bb172.png)
