### PR TITLE
Make `system-ghc` and tool paths configurable

### DIFF
--- a/src/main/scala/intellij/haskell/GlobalInfo.scala
+++ b/src/main/scala/intellij/haskell/GlobalInfo.scala
@@ -3,6 +3,7 @@ package intellij.haskell
 import java.io.File
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import intellij.haskell.util.HaskellFileUtil
 import io.github.soc.directories.ProjectDirectories
@@ -38,8 +39,9 @@ object GlobalInfo {
     new File(toolsStackRootPath, ToolsBinDirName)
   }
 
-  def toolPath(toolName: String): File = {
-    new File(toolsBinPath, toolName)
+  def toolPath(tool: HTool): File = {
+    val name = if (SystemInfo.isWindows) tool.name + ".exe" else tool.name
+    new File(toolsBinPath, name)
   }
 
   def getIntelliJProjectDirectory(project: Project): File = {

--- a/src/main/scala/intellij/haskell/HTool.scala
+++ b/src/main/scala/intellij/haskell/HTool.scala
@@ -1,0 +1,24 @@
+package intellij.haskell
+
+sealed abstract class HTool extends Product with Serializable {
+  def name: String
+}
+
+object HTool {
+
+  case object Hlint extends HTool {
+    def name: String = "hlint"
+  }
+
+  case object Hindent extends HTool {
+    def name: String = "hindent"
+  }
+
+  case object Hoogle extends HTool {
+    def name: String = "hoogle"
+  }
+
+  case object StylishHaskell extends HTool {
+    def name: String = "stylish-haskell"
+  }
+}

--- a/src/main/scala/intellij/haskell/action/HindentReformatAction.scala
+++ b/src/main/scala/intellij/haskell/action/HindentReformatAction.scala
@@ -28,7 +28,7 @@ import intellij.haskell.external.component.StackProjectManager
 import intellij.haskell.external.execution.CommandLine
 import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.util._
-import intellij.haskell.{GlobalInfo, HaskellLanguage, HaskellNotificationGroup}
+import intellij.haskell.{GlobalInfo, HTool, HaskellLanguage, HaskellNotificationGroup}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
@@ -52,8 +52,7 @@ class HindentReformatAction extends AnAction {
 }
 
 object HindentReformatAction {
-  final val HindentName = "hindent"
-  private final val HindentPath = HaskellSettingsState.hindentPath.getOrElse(GlobalInfo.toolPath(HindentName).toString)
+  private final val HindentPath = HaskellSettingsState.hindentPath.getOrElse(GlobalInfo.toolPath(HTool.Hindent).toString)
 
   def format(psiFile: PsiFile, selectionContext: Option[SelectionContext] = None): Boolean = {
     val lineLength = CodeStyle.getSettings(psiFile.getProject).getRightMargin(HaskellLanguage.Instance)
@@ -70,11 +69,11 @@ object HindentReformatAction {
       }
     })
 
-    FutureUtil.waitForValue(project, formatAction, s"reformatting by `$HindentName`") match {
+    FutureUtil.waitForValue(project, formatAction, s"reformatting by `${HTool.Hindent.name}`") match {
       case None => false
       case Some(r) => r match {
         case Left(e) =>
-          HaskellNotificationGroup.logInfoEvent(project, s"Error while reformatting by `$HindentName`. Error: $e")
+          HaskellNotificationGroup.logInfoEvent(project, s"Error while reformatting by `${HTool.Hindent.name}`. Error: $e")
           false
         case Right(sourceCode) =>
           selectionContext match {
@@ -154,4 +153,3 @@ object HindentReformatAction {
     }
   }
 }
-

--- a/src/main/scala/intellij/haskell/action/HindentReformatAction.scala
+++ b/src/main/scala/intellij/haskell/action/HindentReformatAction.scala
@@ -26,6 +26,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import intellij.haskell.external.component.StackProjectManager
 import intellij.haskell.external.execution.CommandLine
+import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.util._
 import intellij.haskell.{GlobalInfo, HaskellLanguage, HaskellNotificationGroup}
 
@@ -52,7 +53,7 @@ class HindentReformatAction extends AnAction {
 
 object HindentReformatAction {
   final val HindentName = "hindent"
-  private final val HindentPath = GlobalInfo.toolPath(HindentName).toString
+  private final val HindentPath = HaskellSettingsState.hindentPath.getOrElse(GlobalInfo.toolPath(HindentName).toString)
 
   def format(psiFile: PsiFile, selectionContext: Option[SelectionContext] = None): Boolean = {
     val lineLength = CodeStyle.getSettings(psiFile.getProject).getRightMargin(HaskellLanguage.Instance)

--- a/src/main/scala/intellij/haskell/action/StylishHaskellReformatAction.scala
+++ b/src/main/scala/intellij/haskell/action/StylishHaskellReformatAction.scala
@@ -25,7 +25,7 @@ import intellij.haskell.external.component.StackProjectManager
 import intellij.haskell.external.execution.CommandLine
 import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.util.{FutureUtil, HaskellEditorUtil, HaskellFileUtil, ScalaUtil}
-import intellij.haskell.{GlobalInfo, HaskellNotificationGroup}
+import intellij.haskell.{GlobalInfo, HTool, HaskellNotificationGroup}
 
 class StylishHaskellReformatAction extends AnAction {
 
@@ -41,8 +41,7 @@ class StylishHaskellReformatAction extends AnAction {
 }
 
 object StylishHaskellReformatAction {
-  final val StylishHaskellName = "stylish-haskell"
-  private final val StylishHaskellPath = HaskellSettingsState.stylishHaskellPath.getOrElse(GlobalInfo.toolPath(StylishHaskellName).toString)
+  private final val StylishHaskellPath = HaskellSettingsState.stylishHaskellPath.getOrElse(GlobalInfo.toolPath(HTool.StylishHaskell).toString)
 
   def versionInfo(project: Project): String = {
     if (StackProjectManager.isStylishHaskellAvailable(project)) {
@@ -62,13 +61,13 @@ object StylishHaskellReformatAction {
           CommandLine.run(project, StylishHaskellPath, Seq(path))
         })
 
-        FutureUtil.waitForValue(project, processOutputFuture, s"reformatting by $StylishHaskellName") match {
+        FutureUtil.waitForValue(project, processOutputFuture, s"reformatting by ${HTool.StylishHaskell.name}") match {
           case None => ()
           case Some(processOutput) =>
             if (processOutput.getStderrLines.isEmpty) {
               HaskellFileUtil.saveFileWithNewContent(psiFile, processOutput.getStdout)
             } else {
-              HaskellNotificationGroup.logInfoEvent(project, s"Error while reformatting by `$StylishHaskellName`. Error: ${processOutput.getStderr}")
+              HaskellNotificationGroup.logInfoEvent(project, s"Error while reformatting by `${HTool.StylishHaskell.name}`. Error: ${processOutput.getStderr}")
             }
         }
       case None => HaskellNotificationGroup.logWarningBalloonEvent(psiFile.getProject, s"Can not reformat file because could not determine path for file `${psiFile.getName}`. File exists only in memory")

--- a/src/main/scala/intellij/haskell/action/StylishHaskellReformatAction.scala
+++ b/src/main/scala/intellij/haskell/action/StylishHaskellReformatAction.scala
@@ -23,6 +23,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import intellij.haskell.external.component.StackProjectManager
 import intellij.haskell.external.execution.CommandLine
+import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.util.{FutureUtil, HaskellEditorUtil, HaskellFileUtil, ScalaUtil}
 import intellij.haskell.{GlobalInfo, HaskellNotificationGroup}
 
@@ -41,7 +42,7 @@ class StylishHaskellReformatAction extends AnAction {
 
 object StylishHaskellReformatAction {
   final val StylishHaskellName = "stylish-haskell"
-  private final val StylishHaskellPath = GlobalInfo.toolPath(StylishHaskellName).toString
+  private final val StylishHaskellPath = HaskellSettingsState.stylishHaskellPath.getOrElse(GlobalInfo.toolPath(StylishHaskellName).toString)
 
   def versionInfo(project: Project): String = {
     if (StackProjectManager.isStylishHaskellAvailable(project)) {

--- a/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration._
 object HLintComponent {
 
   final val HLintName = "hlint"
-  private final val HLintPath = GlobalInfo.toolPath(HLintName).toString
+  private final val HLintPath = HaskellSettingsState.hlintPath.getOrElse(GlobalInfo.toolPath(HLintName).toString)
   private final val Timeout = 500.millis
 
   def check(psiFile: PsiFile): Seq[HLintInfo] = {

--- a/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HLintComponent.scala
@@ -21,7 +21,7 @@ import com.intellij.psi.PsiFile
 import intellij.haskell.external.execution.CommandLine
 import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.util.HaskellFileUtil
-import intellij.haskell.{GlobalInfo, HaskellNotificationGroup}
+import intellij.haskell.{GlobalInfo, HTool, HaskellNotificationGroup}
 import spray.json.JsonParser.ParsingException
 import spray.json.{DefaultJsonProtocol, _}
 
@@ -29,8 +29,7 @@ import scala.concurrent.duration._
 
 object HLintComponent {
 
-  final val HLintName = "hlint"
-  private final val HLintPath = HaskellSettingsState.hlintPath.getOrElse(GlobalInfo.toolPath(HLintName).toString)
+  private final val HLintPath = HaskellSettingsState.hlintPath.getOrElse(GlobalInfo.toolPath(HTool.Hlint).toString)
   private final val Timeout = 500.millis
 
   def check(psiFile: PsiFile): Seq[HLintInfo] = {
@@ -41,7 +40,7 @@ object HLintComponent {
         case Some(path) =>
           val output = runHLint(project, hlintOptions.toSeq ++ Seq("--json", path), ignoreExitCode = true)
           if (output.getExitCode > 0 && output.getStderr.nonEmpty) {
-            HaskellNotificationGroup.logErrorBalloonEvent(project, s"Error while calling $HLintName: ${output.getStderr}")
+            HaskellNotificationGroup.logErrorBalloonEvent(project, s"Error while calling ${HTool.Hlint.name}: ${output.getStderr}")
             Seq()
           } else {
             deserializeHLintInfo(project, output.getStdout)
@@ -51,7 +50,7 @@ object HLintComponent {
           Seq()
       }
     } else {
-      HaskellNotificationGroup.logInfoEvent(psiFile.getProject, s"$HLintName is not (yet) available")
+      HaskellNotificationGroup.logInfoEvent(psiFile.getProject, s"${HTool.Hlint.name} is not (yet) available")
       Seq()
     }
   }

--- a/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
@@ -26,7 +26,7 @@ import intellij.haskell.external.execution.{CommandLine, StackCommandLine}
 import intellij.haskell.psi.{HaskellPsiUtil, HaskellQualifiedNameElement}
 import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.util.{HtmlElement, ScalaFutureUtil}
-import intellij.haskell.{GlobalInfo, HaskellNotificationGroup}
+import intellij.haskell.{GlobalInfo, HTool, HaskellNotificationGroup}
 
 import scala.collection.mutable
 import scala.concurrent.{Future, blocking}
@@ -34,8 +34,7 @@ import scala.jdk.CollectionConverters._
 
 object HoogleComponent {
 
-  final val HoogleName = "hoogle"
-  private final val HooglePath = HaskellSettingsState.hooglePath.getOrElse(GlobalInfo.toolPath(HoogleName).toString)
+  private final val HooglePath = HaskellSettingsState.hooglePath.getOrElse(GlobalInfo.toolPath(HTool.Hoogle).toString)
   private final val HoogleDbName = "hoogle"
 
   def runHoogle(project: Project, pattern: String, count: Int = 100): Option[Seq[String]] = {
@@ -114,7 +113,7 @@ object HoogleComponent {
 
   private def isHoogleFeatureAvailable(project: Project): Boolean = {
     if (!StackProjectManager.isHoogleAvailable(project)) {
-      HaskellNotificationGroup.logInfoEvent(project, s"$HoogleName isn't (yet) available")
+      HaskellNotificationGroup.logInfoEvent(project, s"${HTool.Hoogle.name} isn't (yet) available")
       false
     } else {
       doesHoogleDatabaseExist(project)

--- a/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/HoogleComponent.scala
@@ -24,6 +24,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import intellij.haskell.external.execution.{CommandLine, StackCommandLine}
 import intellij.haskell.psi.{HaskellPsiUtil, HaskellQualifiedNameElement}
+import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.util.{HtmlElement, ScalaFutureUtil}
 import intellij.haskell.{GlobalInfo, HaskellNotificationGroup}
 
@@ -34,7 +35,7 @@ import scala.jdk.CollectionConverters._
 object HoogleComponent {
 
   final val HoogleName = "hoogle"
-  private final val HooglePath = GlobalInfo.toolPath(HoogleName).toString
+  private final val HooglePath = HaskellSettingsState.hooglePath.getOrElse(GlobalInfo.toolPath(HoogleName).toString)
   private final val HoogleDbName = "hoogle"
 
   def runHoogle(project: Project, pattern: String, count: Int = 100): Option[Seq[String]] = {

--- a/src/main/scala/intellij/haskell/external/execution/StackCommandLine.scala
+++ b/src/main/scala/intellij/haskell/external/execution/StackCommandLine.scala
@@ -29,6 +29,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.{CharsetToolkit, VfsUtil}
 import intellij.haskell.HaskellNotificationGroup
 import intellij.haskell.sdk.HaskellSdkType
+import intellij.haskell.settings.HaskellSettingsState
 import intellij.haskell.stackyaml.StackYamlComponent
 import intellij.haskell.util.{HaskellFileUtil, HaskellProjectUtil}
 
@@ -60,7 +61,7 @@ object StackCommandLine {
 
   def installTool(project: Project, toolName: String): Boolean = {
     import intellij.haskell.GlobalInfo._
-    val systemGhcOption = if (StackYamlComponent.isNixEnabled(project)) {
+    val systemGhcOption = if (StackYamlComponent.isNixEnabled(project) || !HaskellSettingsState.useSystemGhc) {
       Seq()
     } else {
       Seq("--system-ghc")

--- a/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
@@ -159,7 +159,7 @@ class HaskellConfigurable extends Configurable {
     state.hlintPath = hlintPathField.getText
     state.hooglePath = hooglePathField.getText
     state.stylishHaskellPath = stylishHaskellPathField.getText
-    state.customPaths = useCustomToolsToggle.isSelected
+    state.customTools = useCustomToolsToggle.isSelected
   }
 
   private def validateREPLTimeout(): Integer = {

--- a/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
@@ -26,6 +26,7 @@ import javax.swing.event.DocumentEvent
 class HaskellConfigurable extends Configurable {
   private var isModifiedByUser = false
   private val hlintOptionsField = new JTextField
+  private val useSystemGhcToggle = new JCheckBox
   private val replTimeoutField = new JTextField
   private val replTimeoutLabel = new JLabel("Changed timeout will take effect after restarting project")
   private val newProjectTemplateNameField = new JTextField
@@ -92,6 +93,7 @@ class HaskellConfigurable extends Configurable {
     addLabeledControl(2, ReplTimeout, replTimeoutField)
     addLabeledControl(3, "", replTimeoutLabel)
     addLabeledControl(4, NewProjectTemplateName, newProjectTemplateNameField)
+    addLabeledControl(5, BuildToolsUsingSystemGhc, useSystemGhcToggle)
 
     settingsPanel.add(new JPanel(), baseGridBagConstraints.setConstraints(
       gridx = 0,
@@ -107,6 +109,7 @@ class HaskellConfigurable extends Configurable {
     val state = HaskellSettingsPersistentStateComponent.getInstance().getState
     state.replTimeout = validREPLTimeout
     state.hlintOptions = hlintOptionsField.getText
+    state.useSystemGhc = useSystemGhcToggle.isSelected
     state.newProjectTemplateName = newProjectTemplateNameField.getText
   }
 
@@ -130,6 +133,7 @@ class HaskellConfigurable extends Configurable {
   override def reset(): Unit = {
     val state = HaskellSettingsPersistentStateComponent.getInstance().getState
     hlintOptionsField.setText(state.hlintOptions)
+    useSystemGhcToggle.setSelected(state.useSystemGhc)
     replTimeoutField.setText(state.replTimeout.toString)
     newProjectTemplateNameField.setText(state.newProjectTemplateName)
   }
@@ -139,4 +143,5 @@ object HaskellConfigurable {
   final val ReplTimeout = "Background REPL timeout in seconds"
   final val HlintOptions = "Hlint options"
   final val NewProjectTemplateName = "Template name for new project"
+  final val BuildToolsUsingSystemGhc = "Build tools using system GHC"
 }

--- a/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
@@ -25,7 +25,6 @@ import javax.swing.event.{ChangeListener, DocumentEvent}
 
 class HaskellConfigurable extends Configurable {
   private var isModifiedByUser = false
-  private var changedPath = false
   private val hlintOptionsField = new JTextField
   private val useSystemGhcToggle = new JCheckBox
   private val replTimeoutField = new JTextField

--- a/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
@@ -101,7 +101,7 @@ class HaskellConfigurable extends Configurable {
       ))
     }
 
-    val labelledControls = List(
+    val labeledControls = List(
       (HlintOptions, hlintOptionsField),
       (ReplTimeout, replTimeoutField),
       ("", replTimeoutLabel),
@@ -114,13 +114,13 @@ class HaskellConfigurable extends Configurable {
       (StylishHaskellPath, stylishHaskellPathField)
     )
 
-    labelledControls.zipWithIndex.foreach {
+    labeledControls.zipWithIndex.foreach {
       case ((label, control), row) => addLabeledControl(row, label, control)
     }
 
     settingsPanel.add(new JPanel(), baseGridBagConstraints.setConstraints(
       gridx = 0,
-      gridy = labelledControls.length,
+      gridy = labeledControls.length,
       weighty = 10.0
     ))
     settingsPanel

--- a/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellConfigurable.scala
@@ -30,6 +30,10 @@ class HaskellConfigurable extends Configurable {
   private val replTimeoutField = new JTextField
   private val replTimeoutLabel = new JLabel("Changed timeout will take effect after restarting project")
   private val newProjectTemplateNameField = new JTextField
+  private val hindentPathField = new JTextField
+  private val hlintPathField = new JTextField
+  private val hooglePathField = new JTextField
+  private val stylishHaskellPathField = new JTextField
 
   override def getDisplayName: String = {
     "Haskell"
@@ -51,6 +55,10 @@ class HaskellConfigurable extends Configurable {
     hlintOptionsField.getDocument.addDocumentListener(listener)
     replTimeoutField.getDocument.addDocumentListener(listener)
     newProjectTemplateNameField.getDocument.addDocumentListener(listener)
+    hindentPathField.getDocument.addDocumentListener(listener)
+    hlintPathField.getDocument.addDocumentListener(listener)
+    hooglePathField.getDocument.addDocumentListener(listener)
+    stylishHaskellPathField.getDocument.addDocumentListener(listener)
 
     class SettingsGridBagConstraints extends GridBagConstraints {
 
@@ -94,6 +102,10 @@ class HaskellConfigurable extends Configurable {
     addLabeledControl(3, "", replTimeoutLabel)
     addLabeledControl(4, NewProjectTemplateName, newProjectTemplateNameField)
     addLabeledControl(5, BuildToolsUsingSystemGhc, useSystemGhcToggle)
+    addLabeledControl(6, HindentPath, hindentPathField)
+    addLabeledControl(7, HlintPath, hlintPathField)
+    addLabeledControl(8, HooglePath, hooglePathField)
+    addLabeledControl(9, StylishHaskellPath, stylishHaskellPathField)
 
     settingsPanel.add(new JPanel(), baseGridBagConstraints.setConstraints(
       gridx = 0,
@@ -111,6 +123,10 @@ class HaskellConfigurable extends Configurable {
     state.hlintOptions = hlintOptionsField.getText
     state.useSystemGhc = useSystemGhcToggle.isSelected
     state.newProjectTemplateName = newProjectTemplateNameField.getText
+    state.hindentPath = hindentPathField.getText
+    state.hlintPath = hlintPathField.getText
+    state.hooglePath = hooglePathField.getText
+    state.stylishHaskellPath = stylishHaskellPathField.getText
   }
 
   private def validateREPLTimeout(): Integer = {
@@ -136,6 +152,10 @@ class HaskellConfigurable extends Configurable {
     useSystemGhcToggle.setSelected(state.useSystemGhc)
     replTimeoutField.setText(state.replTimeout.toString)
     newProjectTemplateNameField.setText(state.newProjectTemplateName)
+    hindentPathField.setText(state.hindentPath)
+    hlintPathField.setText(state.hlintPath)
+    hooglePathField.setText(state.hooglePath)
+    stylishHaskellPathField.setText(state.stylishHaskellPath)
   }
 }
 
@@ -144,4 +164,8 @@ object HaskellConfigurable {
   final val HlintOptions = "Hlint options"
   final val NewProjectTemplateName = "Template name for new project"
   final val BuildToolsUsingSystemGhc = "Build tools using system GHC"
+  final val HindentPath = "Hindent path"
+  final val HlintPath = "Hlint path"
+  final val HooglePath = "Hoogle path"
+  final val StylishHaskellPath = "Stylish Haskell path"
 }

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsPersistentStateComponent.java
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsPersistentStateComponent.java
@@ -58,5 +58,6 @@ public class HaskellSettingsPersistentStateComponent implements PersistentStateC
         public String hlintPath = "";
         public String hooglePath = "";
         public String stylishHaskellPath = "";
+        public Boolean customTools = false;
     }
 }

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsPersistentStateComponent.java
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsPersistentStateComponent.java
@@ -54,5 +54,9 @@ public class HaskellSettingsPersistentStateComponent implements PersistentStateC
         public Boolean reformatCodeBeforeCommit = false;
         public Boolean optimizeImportsBeforeCommit = false;
         public String newProjectTemplateName = "new-template";
+        public String hindentPath = "";
+        public String hlintPath = "";
+        public String hooglePath = "";
+        public String stylishHaskellPath = "";
     }
 }

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsPersistentStateComponent.java
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsPersistentStateComponent.java
@@ -50,6 +50,7 @@ public class HaskellSettingsPersistentStateComponent implements PersistentStateC
     static class HaskellSettingsState {
         public Integer replTimeout = 30;
         public String hlintOptions = "";
+        public Boolean useSystemGhc = true;
         public Boolean reformatCodeBeforeCommit = false;
         public Boolean optimizeImportsBeforeCommit = false;
         public String newProjectTemplateName = "new-template";

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
@@ -50,4 +50,20 @@ object HaskellSettingsState {
   def setOptimizeImportsBeforeCommit(optimize: Boolean): Unit = {
     state.optimizeImportsBeforeCommit = optimize
   }
+
+  def hindentPath: Option[String]= {
+    Option.when(state.hindentPath.nonEmpty)(state.hindentPath)
+  }
+
+  def hlintPath: Option[String]= {
+    Option.when(state.hlintPath.nonEmpty)(state.hlintPath)
+  }
+
+  def hooglePath: Option[String]= {
+    Option.when(state.hooglePath.nonEmpty)(state.hooglePath)
+  }
+
+  def stylishHaskellPath: Option[String]= {
+    Option.when(state.stylishHaskellPath.nonEmpty)(state.stylishHaskellPath)
+  }
 }

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
@@ -29,7 +29,7 @@ object HaskellSettingsState {
     state.hlintOptions
   }
 
-  def useSystemGhc(): Boolean = {
+  def useSystemGhc: Boolean = {
     state.useSystemGhc
   }
 

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
@@ -27,6 +27,10 @@ object HaskellSettingsState {
     state.hlintOptions
   }
 
+  def useSystemGhc(): Boolean = {
+    state.useSystemGhc
+  }
+
   def getNewProjectTemplateName: String = {
     state.newProjectTemplateName
   }

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
@@ -16,6 +16,8 @@
 
 package intellij.haskell.settings
 
+import intellij.haskell.HTool
+
 object HaskellSettingsState {
   private def state = HaskellSettingsPersistentStateComponent.getInstance().getState
 
@@ -65,5 +67,12 @@ object HaskellSettingsState {
 
   def stylishHaskellPath: Option[String]= {
     Option.when(state.stylishHaskellPath.nonEmpty)(state.stylishHaskellPath)
+  }
+
+  def useCustomTool(tool: HTool): Boolean = tool match {
+    case HTool.Hindent => hindentPath.isDefined
+    case HTool.Hlint => hlintPath.isDefined
+    case HTool.Hoogle => hooglePath.isDefined
+    case HTool.StylishHaskell => stylishHaskellPath.isDefined
   }
 }

--- a/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
+++ b/src/main/scala/intellij/haskell/settings/HaskellSettingsState.scala
@@ -53,20 +53,24 @@ object HaskellSettingsState {
     state.optimizeImportsBeforeCommit = optimize
   }
 
+  def customTools: Boolean = {
+    state.customTools
+  }
+
   def hindentPath: Option[String]= {
-    Option.when(state.hindentPath.nonEmpty)(state.hindentPath)
+    Option.when(customTools && state.hindentPath.nonEmpty)(state.hindentPath)
   }
 
   def hlintPath: Option[String]= {
-    Option.when(state.hlintPath.nonEmpty)(state.hlintPath)
+    Option.when(customTools && state.hlintPath.nonEmpty)(state.hlintPath)
   }
 
   def hooglePath: Option[String]= {
-    Option.when(state.hooglePath.nonEmpty)(state.hooglePath)
+    Option.when(customTools && state.hooglePath.nonEmpty)(state.hooglePath)
   }
 
   def stylishHaskellPath: Option[String]= {
-    Option.when(state.stylishHaskellPath.nonEmpty)(state.stylishHaskellPath)
+    Option.when(customTools && state.stylishHaskellPath.nonEmpty)(state.stylishHaskellPath)
   }
 
   def useCustomTool(tool: HTool): Boolean = tool match {


### PR DESCRIPTION
Fixes https://github.com/rikvdkleij/intellij-haskell/issues/446 by adding settings:
- a checkbox for _Build tools using system GHC_
- a text box for _Hindent path_
- a text box for _Hlint path_
- a text box for _Hoogle path_
- a text box for _Stylish Haskell path_