### PR TITLE
Can't find cabal file

### DIFF
--- a/src/main/scala/intellij/haskell/util/HaskellProjectUtil.scala
+++ b/src/main/scala/intellij/haskell/util/HaskellProjectUtil.scala
@@ -25,6 +25,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.{VfsUtilCore, VirtualFile}
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.{PsiElement, PsiFile}
+import com.intellij.util.PathUtilRt
 import intellij.haskell.GlobalInfo
 import intellij.haskell.external.component.HaskellComponentsManager
 import intellij.haskell.module.HaskellModuleType
@@ -78,7 +79,12 @@ object HaskellProjectUtil {
   }
 
   def getModuleDir(module: Module): File = {
-    new File(ModuleUtilCore.getModuleDirPath(module))
+    val path = ModuleUtilCore.getModuleDirPath(module)
+    new File(
+      if (path.endsWith(".idea"))
+        PathUtilRt.getParentPath(path)
+      else path
+    )
   }
 
   def findCabalFiles(project: Project): Iterable[File] = {


### PR DESCRIPTION
In some of our projects, we had issues opening haskell projects that have the following structure:

<img width="413" alt="zasi" src="https://user-images.githubusercontent.com/309334/81684890-ac2e4300-9457-11ea-86fc-97374acae7bd.png">


```
.
├── .idea // <- contains the .iml file here
├── Setup.hs
├── dir1
│   └── task1
│       ├── Task.hs
│       ├── Test.hs
│       └── task.md
├── haske89.cabal
├── stack.yaml
```
And whenever `HaskellProjectUtil.getModuleDir` in https://github.com/i-walker/intellij-haskell/blob/382179707700d835346ad271cc1a4f67d69629f5/src/main/scala/intellij/haskell/external/repl/StackReplsManager.scala#L72. the list will be empty as the Path will be the `.idea` directory. 
The project gets loaded as is, but the user experience is not nice seeing this every time.

I am open for Feedback.