### PR TITLE
Use ANSI escape decoder for command-line output

### DIFF
--- a/src/main/scala/intellij/haskell/external/execution/StackCommandLine.scala
+++ b/src/main/scala/intellij/haskell/external/execution/StackCommandLine.scala
@@ -193,11 +193,11 @@ object StackCommandLine {
 
     override def onTextAvailable(event: ProcessEvent, outputType: Key[_]): Unit = {
       // Workaround to remove the indentation after `-- While building` so the error/warning lines can be properly  parsed.
-      val text = if (whileBuildingTextIsPassed) {
+      val text = AnsiDecoder.decodeAnsiCommandsToString(if (whileBuildingTextIsPassed) {
         event.getText.drop(4)
       } else {
         event.getText
-      }
+      }, outputType)
       progressIndicator.setText(text)
       addToMessageView(text, outputType)
       if (text.startsWith(WhileBuildingText)) {

--- a/src/main/scala/intellij/haskell/external/execution/StackCommandLine.scala
+++ b/src/main/scala/intellij/haskell/external/execution/StackCommandLine.scala
@@ -187,6 +187,7 @@ object StackCommandLine {
     private final val WhileBuildingText = "--  While building "
     private final var whileBuildingTextIsPassed = false
 
+    private val ansiEscapeDecoder = new AnsiEscapeDecoder()
     private val previousMessageLines = new LinkedBlockingDeque[String]
     @volatile
     private var globalError = false
@@ -197,7 +198,7 @@ object StackCommandLine {
         event.getText.drop(4)
       } else {
         event.getText
-      }, outputType)
+      }, outputType, ansiEscapeDecoder)
       progressIndicator.setText(text)
       addToMessageView(text, outputType)
       if (text.startsWith(WhileBuildingText)) {


### PR DESCRIPTION
This will use IDEA-backed ANSI decoder to decode the escape sequences, so `[0m` won't be shown to the user.

Closes #585.