### PR TITLE
Feature/create stub

### DIFF
--- a/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
+++ b/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
@@ -151,7 +151,7 @@ object HaskellAnnotator {
 
   private final val DeprecatedPattern = """.*In the use of.*[‘`](.*)[’'].*Deprecated: "Use ([^ ]+).*"""".r
 
-  private final val HolePattern = """warning: \[-Wtyped-holes].*?Found hole: ([^ ]+)(.*?) In the.*""".r
+  private final val HolePattern = """warning: \[-Wtyped-holes].*?Found hole: ([^ ]+)(.*?) (?:Or perhaps|In the).*""".r
 
   // File which could not be loaded because project was not yet build
   private final val NotLoadedFiles = new ConcurrentHashMap[Project, Set[PsiFile]]

--- a/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
+++ b/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
@@ -34,6 +34,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.TreeUtil
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.rename.RenameUtil
 import intellij.haskell.editor.{HaskellImportOptimizer, HaskellProblemsView}
 import intellij.haskell.external.component._
 import intellij.haskell.external.execution._
@@ -353,7 +354,7 @@ class CreateStubIntentionAction(name: String, typeSignature: String) extends Has
     if (dialog.showAndGet())
 
     Option(file.findElementAt(offset)) match {
-      case Some(e) => for {
+      case Some(e) => if (RenameUtil.isValidName(project, e, dialog.getName)) for {
         newName <- HaskellElementFactory.createQNameElement(project, dialog.getName)
         topDeclaration <- Option(TreeUtil.findParent(e.getNode, HaskellTypes.HS_TOP_DECLARATION))
         moduleBody <- Option(topDeclaration.getPsi.getParent)

--- a/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
+++ b/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
@@ -350,7 +350,7 @@ class CreateStubIntentionAction(name: String, typeSignature: String) extends Has
   override def invoke(project: Project, editor: Editor, file: PsiFile): Unit = {
     val offset = editor.getCaretModel.getOffset
 
-    val dialog = new EnterNameDialog("Enter variable name")
+    val dialog = new EnterNameDialog("Enter variable name", name.drop(1))
     if (dialog.showAndGet())
 
     Option(file.findElementAt(offset)) match {

--- a/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
+++ b/src/main/scala/intellij/haskell/annotator/HaskellAnnotator.scala
@@ -39,6 +39,7 @@ import intellij.haskell.external.component._
 import intellij.haskell.external.execution._
 import intellij.haskell.psi._
 import intellij.haskell.runconfig.console.HaskellConsoleView
+import intellij.haskell.ui.EnterNameDialog
 import intellij.haskell.util._
 import intellij.haskell.{HaskellFile, HaskellFileType, HaskellNotificationGroup}
 
@@ -346,9 +347,12 @@ class CreateStubIntentionAction(name: String, typeSignature: String) extends Has
   override def invoke(project: Project, editor: Editor, file: PsiFile): Unit = {
     val offset = editor.getCaretModel.getOffset
 
+    val dialog = new EnterNameDialog("Enter variable name")
+    if (dialog.showAndGet())
+
     Option(file.findElementAt(offset)) match {
       case Some(e) => for {
-        newName <- HaskellElementFactory.createQNameElement(project, "helper")
+        newName <- HaskellElementFactory.createQNameElement(project, dialog.getName)
         topDeclaration <- Option(TreeUtil.findParent(e.getNode, HaskellTypes.HS_TOP_DECLARATION))
         moduleBody <- Option(topDeclaration.getPsi.getParent)
         sigDecl <- HaskellElementFactory.createTopDeclaration(project, newName.getName + typeSignature)

--- a/src/main/scala/intellij/haskell/ui/EnterNameDialog.scala
+++ b/src/main/scala/intellij/haskell/ui/EnterNameDialog.scala
@@ -1,0 +1,27 @@
+package intellij.haskell.ui
+
+import java.awt.BorderLayout
+
+import com.intellij.openapi.ui.DialogWrapper
+import javax.swing.{JComponent, JLabel, JPanel, JTextField}
+
+class EnterNameDialog(prompt: String) extends DialogWrapper(true) {
+  private val textField = new JTextField(10)
+  init()
+  setTitle(prompt)
+  override def createCenterPanel(): JComponent = {
+    val dialogPanel: JPanel = new JPanel(new BorderLayout)
+
+    val label: JLabel = new JLabel(prompt)
+    dialogPanel.add(label, BorderLayout.NORTH)
+
+    dialogPanel.add(textField, BorderLayout.SOUTH)
+
+    dialogPanel
+  }
+
+  override def getPreferredFocusedComponent: JComponent = textField
+
+  def getName: String = textField.getText
+
+}

--- a/src/main/scala/intellij/haskell/ui/EnterNameDialog.scala
+++ b/src/main/scala/intellij/haskell/ui/EnterNameDialog.scala
@@ -5,8 +5,8 @@ import java.awt.BorderLayout
 import com.intellij.openapi.ui.DialogWrapper
 import javax.swing.{JComponent, JLabel, JPanel, JTextField}
 
-class EnterNameDialog(prompt: String) extends DialogWrapper(true) {
-  private val textField = new JTextField(10)
+class EnterNameDialog(prompt: String, suggestion: String = "") extends DialogWrapper(true) {
+  private val textField = if (suggestion.isEmpty) new JTextField(10) else new JTextField(suggestion)
   init()
   setTitle(prompt)
   override def createCenterPanel(): JComponent = {


### PR DESCRIPTION
This PR allows the user to create a stub to satisfy a typed hole, for example for a scenario described [here](https://github.com/rikvdkleij/intellij-haskell/issues/629#issuecomment-738959589).

Example:
```haskell
process :: M.Map String Int -> Bool
process = M.foldl' _ False
```

can be converted to
```haskell
process :: M.Map String Int -> Bool
process = M.foldl' go False

go :: Bool -> Int -> Bool
go = undefined
```

via an Intention Action (i.e. by pressing alt+Enter when the cursor is over the typed hole).