### PR TITLE
Documentation in code completion

### DIFF
--- a/src/main/scala/intellij/haskell/editor/HaskellCompletionContributor.scala
+++ b/src/main/scala/intellij/haskell/editor/HaskellCompletionContributor.scala
@@ -462,12 +462,12 @@ class HaskellCompletionContributor extends CompletionContributor {
   }
 
   private def createLookupElement(moduleIdentifier: ModuleIdentifier, addParens: Boolean = false): LookupElementBuilder = {
-    addWiths(LookupElementBuilder.create(
-      if (moduleIdentifier.operator && addParens)
-        s"""(${moduleIdentifier.name})"""
-      else
-        moduleIdentifier.name
-    ), moduleIdentifier)
+    val completion = if (moduleIdentifier.operator && addParens)
+      s"""(${moduleIdentifier.name})"""
+    else
+      moduleIdentifier.name
+
+    addWiths(LookupElementBuilder.create(moduleIdentifier, completion), moduleIdentifier)
   }
 
   def createLocalLookupElement(namedElement: HaskellNamedElement): LookupElementBuilder = {

--- a/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
+++ b/src/main/scala/intellij/haskell/external/component/HaskellDocumentationProvider.scala
@@ -96,15 +96,15 @@ class HaskellDocumentationProvider extends AbstractDocumentationProvider {
 
   override def getDocumentationElementForLookupItem(psiManager: PsiManager, obj: Object, element: PsiElement): PsiElement = {
     obj match {
-      case s: String =>
-        val dotIndex = s.lastIndexOf(".")
+      case mi: ModuleIdentifier =>
+        val dotIndex = mi.name.lastIndexOf(".")
         val name = if (dotIndex >= 0) {
-          s.substring(dotIndex + 1)
+          mi.name.substring(dotIndex + 1)
         } else {
-          s
+          mi.name
         }
 
-        NameInfoComponent.findNameInfoByQualifiedName(element.getContainingFile, s) match {
+        NameInfoComponent.findNameInfoByQualifiedName(element.getContainingFile, mi.name) match {
           case Right(infos) => infos.headOption match {
             case Some(info) => HaskellReference.findIdentifiersByNameInfo(info, name, psiManager.getProject) match {
               case Right((_, hne, _)) => Some(hne)

--- a/src/main/scala/intellij/haskell/external/component/NameInfoComponent.scala
+++ b/src/main/scala/intellij/haskell/external/component/NameInfoComponent.scala
@@ -70,7 +70,12 @@ private[component] object NameInfoComponent {
       case None => qualifiedNameElement.getName
       case Some(q) => q + "." + qualifiedNameElement.getIdentifierElement.getName
     }
-    val key = Key(psiFile, qName)
+
+    findNameInfoByQualifiedName(psiFile, qName)
+  }
+
+  def findNameInfoByQualifiedName(psiFile: PsiFile, qualifiedName: String): NameInfoResult = {
+    val key = Key(psiFile, qualifiedName)
 
     ProgressManager.checkCanceled()
 

--- a/src/main/scala/intellij/haskell/navigation/HaskellReference.scala
+++ b/src/main/scala/intellij/haskell/navigation/HaskellReference.scala
@@ -324,9 +324,12 @@ object HaskellReference {
   }
 
   def findIdentifiersByNameInfo(nameInfo: NameInfo, namedElement: HaskellNamedElement, project: Project): Either[NoInfo, (Option[String], HaskellNamedElement, Option[String])] = {
+    findIdentifiersByNameInfo(nameInfo, namedElement.getName, project)
+  }
+
+  def findIdentifiersByNameInfo(nameInfo: NameInfo, name: String, project: Project): Either[NoInfo, (Option[String], HaskellNamedElement, Option[String])] = {
     ProgressManager.checkCanceled()
 
-    val name = namedElement.getName
     nameInfo match {
       case pni: ProjectNameInfo =>
         val (virtualFile, psiFile) = HaskellFileUtil.findFileInRead(project, pni.filePath)


### PR DESCRIPTION
Fixes issue #638

Preview:
![screenshot-doc](https://user-images.githubusercontent.com/3309700/108609276-2ae3e380-73cd-11eb-88a6-49bf2de9a73f.png)

Using `originalElement` in

```scala
getQuickNavigateInfo(element: PsiElement, originalElement: PsiElement)
```
does not work because it seems to be `PsiWhiteSpace` when using code completion, so I changed it to always use `element`. I am not sure if this breaks other features.

Sometimes I can not navigate through the options using the arrow keys on my keyboard, only using my mouse. I don't know why this is happening.

The documention lookup is only done when pressing CTRL+Q so it should not affect the responsiveness.
