### PR TITLE
Add default sdk home path for windows

### DIFF
--- a/src/main/scala/intellij/haskell/sdk/HaskellSdkType.scala
+++ b/src/main/scala/intellij/haskell/sdk/HaskellSdkType.scala
@@ -39,6 +39,8 @@ class HaskellSdkType extends SdkType("Haskell Tool Stack SDK") {
       "/usr/local/bin/stack"
     else if (SystemInfo.isMac)
       "/usr/local/bin/stack"
+    else if (SystemInfo.isWindows)
+      s"${sys.env.get("APPDATA")}\\local\\bin\\stack.exe"
     else null
   }
 


### PR DESCRIPTION
It's the recommended path by stack https://docs.haskellstack.org/en/stable/install_and_upgrade/#path