### PR TITLE
Update sbt-idea-plugin -> 3.20.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.14.3")
+addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.20.0")
 
 resolvers += Resolver.url("jetbrains-bintray",
   url("https://dl.bintray.com/jetbrains/sbt-plugins/"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION
Specifically to get fix for downloading jbr-aarch64 for M1/M2 Macs.

https://github.com/JetBrains/sbt-idea-plugin/commit/20f64a10e30ffed3ae92667760101d650951ff27